### PR TITLE
Tiny README Fix

### DIFF
--- a/fsh/README.md
+++ b/fsh/README.md
@@ -12,7 +12,7 @@ After you check out mCODE from Github, install SUSHI (the FSH compiler), [as ins
 
 To compile mCODE, open a command window and navigate to the directory where mCODE has been checked out. Issue the following command:
 
-`$ sushi .
+`$ sushi .`
 
 ## Running the IG Publisher
 


### PR DESCRIPTION
Really small README fix for an issue I noticed while looking at the repo.  Figured I'd submit a PR before I forgot about it 🙂 .

Changed `` `$ sushi . `` -> `` `$ sushi .` `` to address missing `` ` ``