### PR TITLE
Use fsh.ini to force IG Auto-Build to use beta version of SUSHI

### DIFF
--- a/fsh.ini
+++ b/fsh.ini
@@ -1,0 +1,2 @@
+[FSH]
+sushi-version=beta


### PR DESCRIPTION
This PR gets auto-build working again by forcing the publisher to use the SUSHI beta.  Proof it is working:
http://build.fhir.org/ig/HL7/fhir-mCODE-ig/branches/fsh-ini/index.html
