### PR TITLE
Revert to using CancerStageParent rather than all the child profiles

### DIFF
--- a/input/fsh/CancerCondition.fsh
+++ b/input/fsh/CancerCondition.fsh
@@ -37,7 +37,7 @@ Condition resources associated with an mCODE patient with a Condition.code in th
 
 * ^abstract = false
 * code from PrimaryOrUncertainBehaviorCancerDisorderVS (extensible)
-* stage.assessment only Reference(TNMClinicalStageGroup or TNMClinicalPrimaryTumorCategory or TNMClinicalRegionalNodesCategory or TNMClinicalDistantMetastasesCategory or TNMPathologicalStageGroup or TNMPathologicalPrimaryTumorCategory or TNMPathologicalRegionalNodesCategory or TNMPathologicalDistantMetastasesCategory)
+* stage.assessment only Reference(CancerStageParent)
 
 
 Profile: SecondaryCancerCondition


### PR DESCRIPTION
Per @markkramerus:

> Now that I added this line in CancerStageParent:
>
>     * code from LoincCancerStagingCodesVS (required)
>
> I think we can go back to the way it was without creating an IGP error.