### PR TITLE
Remove (commented out) inline extension

### DIFF
--- a/input/fsh/CancerDiseaseStatus.fsh
+++ b/input/fsh/CancerDiseaseStatus.fsh
@@ -6,15 +6,11 @@ Description:    "A clinician's qualitative judgment on the current trend of the 
 
 Note: The LOINC code chosen to represent this observation (LOINC 88040-1, Response to cancer treatment) does not precisely match the meaning of this profile, but it is the closest available LOINC code at the present time. It is acknowledged that the disease status is different than the status of the disease due to treatment, although in the context of an oncologist visit, disease status can mean response to treatment for patients under their care. However, the LOINC code 88041-2 is more granular than the definition of the profile because cancer disease status is observable regardless of whether the patient is under treatment. The plan is to request a new LOINC code that represents cancer disease status, as it is defined here, and replace the current LOINC code with the new code before normative publication of mCODE.
 
-Conformance statement: 
+Conformance statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 88040-1 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
 
 * extension contains EvidenceType named evidenceType 0..*
-/* extension[evidenceType] ^short = "Evidence Type"
-* extension[evidenceType] ^definition = "Categorization of the kind of evidence used as input to the clinical judgment. This corresponds to both the S and O in SOAP."
-* extension[evidenceType].valueCodeableConcept from CancerDiseaseStatusEvidenceTypeVS (required)
-*/
 * status and code and subject and effective[x] and valueCodeableConcept MS
 * specimen 0..0
 * device 0..0


### PR DESCRIPTION
The extension for EvidenceType is only used in one place, so Mark tried changing it to an inline extension so we could have one less StructureDefinition. However, the IG Publisher raised an error that the URL for this extension had to be an absolute URL. The URL of inline extensions are like just names, like "evidenceType". So Mark reverted back to a Standalone extension.

This commit cleans up the leftover inline extension code.