### PR TITLE
Correct two issues discovered while putting together Block-Vote-1

### DIFF
--- a/input/fsh/SD_DiseaseStatus.fsh
+++ b/input/fsh/SD_DiseaseStatus.fsh
@@ -18,7 +18,6 @@ Observation resources associated with an mCODE patient with Observation.code LOI
 * hasMember 0..0
 * component 0..0
 * subject 1..1
-* value[x] 1..1
 * code = LNC#88040-1 //"Response to cancer treatment"
 * subject only Reference(CancerPatient)
 * focus only Reference(PrimaryCancerCondition or SecondaryCancerCondition)

--- a/input/fsh/SD_Procedures.fsh
+++ b/input/fsh/SD_Procedures.fsh
@@ -5,7 +5,7 @@ Title:  "Cancer-Related Procedure Parent"
 Description: "Abstract parent class for cancer procedure profiles."
 * ^abstract = true
 * extension contains
-    TreatmentIntent named treatmentIntent 0..1
+    TreatmentIntent named treatmentIntent 0..1 MS
 * category 1..1
 * reasonCode from AnyCancerDisorderVS (extensible)
 * reasonReference only Reference(CancerConditionParent)  // rather than Primary, Secondary, Tumor
@@ -13,10 +13,10 @@ Description: "Abstract parent class for cancer procedure profiles."
 * recorder only Reference(Practitioner or PractitionerRole)
 * performer.actor only Reference(Practitioner or PractitionerRole or Organization)
 * bodySite.extension contains
-    LocationQualifier named locationQualifier 0..1
+    LocationQualifier named locationQualifier 0..1 MS
 * bodySite.extension[locationQualifier] ^short = "Location Qualifier"
 * bodySite.extension[locationQualifier] ^definition = "Qualifier to refine the anatomical location. These include qualifiers for laterality, relative location, directionality, number, and plane."
-* reasonCode and reasonReference and extension[treatmentIntent] and bodySite and bodySite.extension[locationQualifier] MS
+* reasonCode and reasonReference and bodySite MS
 * extension[treatmentIntent] ^short = "Treatment Intent"
 * extension[treatmentIntent] ^definition = "The purpose of a treatment."
 
@@ -33,6 +33,10 @@ Procedure resources associated with an mCODE patient with Procedure.category SNO
 * category = SCT#53438000 //"Radiation therapy procedure or service (procedure)"
 * code from RadiationProcedureVS (extensible)
 * bodySite from RadiationTargetBodySiteVS (extensible)
+* extension contains
+    TerminationReason named terminationReason 0..1 MS
+* extension[terminationReason] ^short = "Termination Reason"
+* extension[terminationReason] ^definition = "A code explaining an unplanned or premature termination of a plan of treatment, course of medication, or research study."
 
 Profile:  CancerRelatedSurgicalProcedure
 Parent:   CancerRelatedProcedureParent


### PR DESCRIPTION
1) https://jira.hl7.org/browse/FHIR-27783 -- changed proposed resolution to "Not Persuasive" -- we will continue to allow a CancerDiseaseStatus with no value and a dataAbsentReason (because DAR is allowed in every other type of Observation).

2) https://jira.hl7.org/browse/FHIR-27856 -- somehow we lost TerminationReason on CancerRelatedRadiationProcedure so I re-added it, and as indicated in that issue, made it MS