### PR TITLE
Fix search param types

### DIFF
--- a/FHIR-us-mcode.xml
+++ b/FHIR-us-mcode.xml
@@ -72,7 +72,6 @@
 <artifact id="StructureDefinition/mcode-genetic-specimen" key="genetic-specimen" name="Genetic Specimen"/>
 <artifact id="ValueSet/mcode-genetic-specimen-type-vs" key="genetic-specimen-type-value-set" name="Genetic Specimen Type Value Set"/>
 <artifact id="StructureDefinition/mcode-genomic-region-studied" key="genomic-region-studied" name="Genomic Region Studied"/>
-<artifact id="OperationDefinition/mcode-patient-everything" key="OperationDefinition-mcode-patient-everything" name="GetPatientBundleOperation"/>
 <artifact deprecated="true" id="ValueSet/mcode-hgvs-sequence-variant-nomenclature-value-set" key="hgvs-sequence-variant-nomenclature-value-set" name="HGVS Sequence Variant Nomenclature Value Set"/>
 <artifact id="ValueSet/mcode-hgnc-vs" key="hugo-gene-nomenclature-committee-gene-names-value-set" name="HUGO Gene Nomenclature Committee Gene Names Value Set"/>
 <artifact deprecated="true" id="Extension/mcode-histology-morphology-behavior-extension" key="histology-morphology-behavior-extension" name="Histology Morphology Behavior Extension"/>
@@ -86,6 +85,7 @@
 <artifact id="ValueSet/mcode-location-qualifier-vs" key="ValueSet-mcode-location-qualifier-vs" name="Location Qualifier Value Set"/>
 <artifact id="ValueSet/mcode-tumor-size-method-vs" key="ValueSet-mcode-tumor-size-method-vs" name="Methods for measuring tumor size"/>
 <artifact deprecated="true" key="Observation" name="Observation"/>
+<artifact id="OperationDefinition/mcode-patient-everything" key="OperationDefinition-mcode-patient-everything" name="Operation-mcode-patient-everything"/>
 <artifact id="StructureDefinition/mcode-performance-status-parent" key="StructureDefinition-mcode-performance-status-parent" name="Performance Status Parent"/>
 <artifact id="ValueSet/mcode-present-absent-unknown" key="ValueSet-mcode-present-absent-unknown" name="Present-Absent-Unknown"/>
 <artifact id="StructureDefinition/mcode-primary-cancer-condition" key="primary-cancer-condition" name="Primary Cancer Condition"/>

--- a/input/fsh/CS_Capabilities.fsh
+++ b/input/fsh/CS_Capabilities.fsh
@@ -55,12 +55,6 @@ RuleSet: mCODE_CS_Server
 * rest[serverSlice].resource[PatientSlice].interaction[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
 * rest[serverSlice].resource[PatientSlice].interaction[0].extension.valueCode = #SHALL
 
-* rest[serverSlice].resource[PatientSlice].searchParam[0].name = "_id"
-* rest[serverSlice].resource[PatientSlice].searchParam[0].type = #uri
-* rest[serverSlice].resource[PatientSlice].searchParam[0].definition = "http://hl7.org/fhir/us/mcode/SearchParameter/Patient-id"
-* rest[serverSlice].resource[PatientSlice].searchParam[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
-* rest[serverSlice].resource[PatientSlice].searchParam[0].extension.valueCode = #SHALL
-
 // GET [base]/$mcode-patient-bundle/[id]
 * rest[serverSlice].operation[0].name = "mcode-patient-bundle"
 * rest[serverSlice].operation[0].definition = "http://hl7.org/fhir/us/mcode/OperationDefinition/mcode-patient-everything"
@@ -105,7 +99,7 @@ Description: "Defines the preferred requirements for an mCODE Data Sender"
 * rest[serverSlice].resource[PatientSlice].interaction[1].documentation = "Identify Patient resources conforming to mCODE's CancerPatient profile via tagging with meta.profile."
 
 * rest[serverSlice].resource[PatientSlice].searchParam[0].name = "_profile"
-* rest[serverSlice].resource[PatientSlice].searchParam[0].type = #token
+* rest[serverSlice].resource[PatientSlice].searchParam[0].type = #uri
 * rest[serverSlice].resource[PatientSlice].searchParam[0].definition = "http://hl7.org/fhir/SearchParameter/Resource-profile"
 * rest[serverSlice].resource[PatientSlice].searchParam[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
 * rest[serverSlice].resource[PatientSlice].searchParam[0].extension.valueCode = #SHALL
@@ -124,10 +118,10 @@ Description: "Defines the primary fallback requirements for an mCODE Data Sender
 * insert mCODE_CS_Server
 
 // GET [base]/Patient?_has:Condition:subject:code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs
-* rest[serverSlice].resource[PatientSlice].interaction[0].code = #search-type
-* rest[serverSlice].resource[PatientSlice].interaction[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
-* rest[serverSlice].resource[PatientSlice].interaction[0].extension.valueCode = #SHALL
-* rest[serverSlice].resource[PatientSlice].interaction[0].documentation = "Identify Patient resources conforming to mCODE's CancerPatient profile via reverse chaining searching for conditions in a specific ValueSet."
+* rest[serverSlice].resource[PatientSlice].interaction[1].code = #search-type
+* rest[serverSlice].resource[PatientSlice].interaction[1].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[serverSlice].resource[PatientSlice].interaction[1].extension.valueCode = #SHALL
+* rest[serverSlice].resource[PatientSlice].interaction[1].documentation = "Identify Patient resources conforming to mCODE's CancerPatient profile via reverse chaining searching for conditions in a specific ValueSet."
 
 * rest[serverSlice].resource[PatientSlice].searchParam[0].name = "_has:Condition:subject:code:in"
 * rest[serverSlice].resource[PatientSlice].searchParam[0].type = #uri
@@ -168,6 +162,13 @@ Description: "Defines the tertiary fallback requirements for an mCODE Data Sende
 // GET [base]/Condition?code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs
 * insert mCODE_CS_Server_Fallback
 
+// GET [base]/Patient?_id=id1|id2|id3
+* rest[serverSlice].resource[PatientSlice].searchParam[0].name = "_id"
+* rest[serverSlice].resource[PatientSlice].searchParam[0].type = #token
+* rest[serverSlice].resource[PatientSlice].searchParam[0].definition = "http://hl7.org/fhir/us/mcode/SearchParameter/Patient-id"
+* rest[serverSlice].resource[PatientSlice].searchParam[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[serverSlice].resource[PatientSlice].searchParam[0].extension.valueCode = #SHALL
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////// Client //////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -180,16 +181,9 @@ RuleSet: mCODE_CS_Client
 * rest[clientSlice].resource[PatientSlice].supportedProfile[0] = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient"
 
 // GET [base]/Patient/[id]
-// TODO: is this the correct way to specify this? Do I need an additional `searchParam` to specify `[id]`?
 * rest[clientSlice].resource[PatientSlice].interaction[0].code = #read
 * rest[clientSlice].resource[PatientSlice].interaction[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
 * rest[clientSlice].resource[PatientSlice].interaction[0].extension.valueCode = #SHALL
-
-* rest[clientSlice].resource[PatientSlice].searchParam[0].name = "_id"
-* rest[clientSlice].resource[PatientSlice].searchParam[0].type = #uri
-* rest[clientSlice].resource[PatientSlice].searchParam[0].definition = "http://hl7.org/fhir/us/mcode/SearchParameter/Patient-id"
-* rest[clientSlice].resource[PatientSlice].searchParam[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
-* rest[clientSlice].resource[PatientSlice].searchParam[0].extension.valueCode = #SHALL
 
 // GET [base]/$mcode-patient-bundle/[id]
 * rest[clientSlice].operation[0].name = "mcode-patient-bundle"
@@ -235,7 +229,7 @@ Description: "Defines the preferred requirements for an mCODE Data Receiver"
 * rest[clientSlice].resource[PatientSlice].interaction[1].documentation = "Identify Patient resources conforming to mCODE's CancerPatient profile via tagging with meta.profile."
 
 * rest[clientSlice].resource[PatientSlice].searchParam[0].name = "_profile"
-* rest[clientSlice].resource[PatientSlice].searchParam[0].type = #token
+* rest[clientSlice].resource[PatientSlice].searchParam[0].type = #uri
 * rest[clientSlice].resource[PatientSlice].searchParam[0].definition = "http://hl7.org/fhir/SearchParameter/Resource-profile"
 * rest[clientSlice].resource[PatientSlice].searchParam[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
 * rest[clientSlice].resource[PatientSlice].searchParam[0].extension.valueCode = #SHALL
@@ -297,5 +291,12 @@ Description: "Defines the tertiary fallback requirements for an mCODE Data Recei
 
 // GET [base]/Condition?code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs
 * insert mCODE_CS_Client_Fallback
+
+// GET [base]/Patient?_id=id1|id2|id3
+* rest[clientSlice].resource[PatientSlice].searchParam[0].name = "_id"
+* rest[clientSlice].resource[PatientSlice].searchParam[0].type = #token
+* rest[clientSlice].resource[PatientSlice].searchParam[0].definition = "http://hl7.org/fhir/us/mcode/SearchParameter/Patient-id"
+* rest[clientSlice].resource[PatientSlice].searchParam[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[clientSlice].resource[PatientSlice].searchParam[0].extension.valueCode = #SHALL
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/input/fsh/CS_Capabilities.fsh
+++ b/input/fsh/CS_Capabilities.fsh
@@ -58,7 +58,7 @@ RuleSet: mCODE_CS_Server
 // GET [base]/$mcode-patient-bundle/[id]
 * rest[serverSlice].operation[0].name = "mcode-patient-bundle"
 * rest[serverSlice].operation[0].definition = "http://hl7.org/fhir/us/mcode/OperationDefinition/mcode-patient-everything"
-* rest[serverSlice].operation[0].extension.url = "http://hl7.org/fhir/us/mcode/OperationDefinition/mcode-patient-everything"
+* rest[serverSlice].operation[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
 * rest[serverSlice].operation[0].extension.valueCode = #SHALL
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -188,7 +188,7 @@ RuleSet: mCODE_CS_Client
 // GET [base]/$mcode-patient-bundle/[id]
 * rest[clientSlice].operation[0].name = "mcode-patient-bundle"
 * rest[clientSlice].operation[0].definition = "http://hl7.org/fhir/us/mcode/OperationDefinition/mcode-patient-everything"
-* rest[clientSlice].operation[0].extension.url = "http://hl7.org/fhir/us/mcode/OperationDefinition/mcode-patient-everything"
+* rest[clientSlice].operation[0].extension.url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
 * rest[clientSlice].operation[0].extension.valueCode = #SHALL
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/input/fsh/SP_SearchParameters.fsh
+++ b/input/fsh/SP_SearchParameters.fsh
@@ -26,7 +26,7 @@ Title: "Search by code:in in Conditions"
 * description = "This SearchParameter enables query of conditions by code with the `in` modifier."
 * code = #code
 * base[0] = #Condition
-* type = #token
+* type = #uri
 * expression = "Condition.code"
 * xpath = "f:Condition/f:code"
 * xpathUsage = #normal

--- a/input/fsh/SP_SearchParameters.fsh
+++ b/input/fsh/SP_SearchParameters.fsh
@@ -19,7 +19,6 @@ Instance: Condition-code
 InstanceOf: SearchParameter
 Title: "Search by code:in in Conditions"
 * url = "http://hl7.org/fhir/us/mcode/SearchParameter/Condition-code"
-* derivedFrom = "http://hl7.org/fhir/SearchParameter/clinical-code"
 * name = "code"
 * status = #draft
 * experimental = true


### PR DESCRIPTION
- Fixes some search param types that were set to `#token` when they should have been `#uri`
- Fixes a bug where multiple `searchParams` were assigned to index `[0]` inadvertently (this is an easy mistake to make when using `RuleSet`s to keep the FSH DRY), causing silent overwriting
- Moves support for `GET [base]/Patient?_id=id1|id2|id3|...` to just the 3rd fallback. Before this was required for all the CapabilityStatements, but it's only strictly necessary when getting Conditions and Patients in separate requests (in the 3rd fallback).