### PR TITLE
Fix errors in mCODECancerGeneticVariantExample02

### DIFF
--- a/input/fsh/EX_Example1_Genomics.fsh
+++ b/input/fsh/EX_Example1_Genomics.fsh
@@ -11,7 +11,7 @@ Description: "mCODE Example for Cancer Genetic Variant"
 * effectiveDateTime = "2019-04-01"
 * valueCodeableConcept = LNC#LA9633-4 "Present"
 * interpretation = SCT#10828004 "Positive (qualifier value)"
-* component[GeneStudied].valueCodeableConcept = HGNC#HGNC:11389 "STK11" 
+* component[GeneStudied].valueCodeableConcept = HGNC#HGNC:11389 "STK11"
 // variant type: single nucleotide variant
 // https://www.ncbi.nlm.nih.gov/clinvar/variation/619728/
 // https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:8023
@@ -36,7 +36,7 @@ Description: "mCODE Example for Cancer Genetic Variant"
 * effectiveDateTime = "2019-04-01"
 * valueCodeableConcept = LNC#LA9633-4 "Present"
 * component[GeneStudied].valueCodeableConcept = HGNC#HGNC:1100 "BRCA1" // NOTE: HGNC and HGVS codes have special characters in them so SUSHI needs to handle this.
-* component[GenomicDNAChange].valueCodeableConcept = HGVS#NG_005905.2:g.126148_126152GTAAA[1] "NG_005905.2:g.126148_126152GTAAA[1]"
+* component[GenomicDNAChange].valueCodeableConcept = HGVS#NG_005905.2:g.126148_126152del "NG_005905.2:g.126148_126152del"
 * component[GenomicSourceClass].valueCodeableConcept = LNC#LA6683-2 "Germline"
 
 Instance: mCODECancerGenomicsReportExample1


### PR DESCRIPTION
- [x] **Error 1: HGVS syntax**

        Original: HGVS#NG_005905.2:g.126148_126152GTAAA[1]
        New:      HGVS#NG_005905.2:g.126148_126152del

    Note that the original did not validate on https://variantvalidator.org/service/validate/

    This is the ClinVar page for this variant:
    https://www.ncbi.nlm.nih.gov/clinvar/variation/37542/

    The ClinGen page for this variant:
    http://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/by_caid?caid=CA002368

    The ClinGen page has the preferred/valid HGVS syntax for the variant.

- [ ] **Error 2: LOINC code for GenomicSourceClass slice**

    `* component[GenomicSourceClass].valueCodeableConcept = LNC#LA6683-2 "Germline"` causes an “Unable to resolve value set (from http://tx.fhir.org/r4)” error. Replacing that LOINC code with `LNC#LA6684-0 "Somatic"` works fine.

    Both are part of the [preferred value set for 48002-0](https://loinc.org/48002-0/). 

    - [QA page showing error for germline code](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/branches/genomics-error1-mfm/qa.min.html#_scratch_ig-build-temp-E60B3X_repo_fsh-generated_resources_Observation-mCODECancerGeneticVariantExample2)
    - [QA page showing no error for somatic code](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/branches/genomics-error1-somatic-mfm/qa.min.html#_scratch_ig-build-temp-HTD7K4_repo_fsh-generated_resources_Observation-mCODECancerGeneticVariantExample2)
    - [diff on GitHub showing what’s different between these 2 builds](https://github.com/HL7/fhir-mCODE-ig/compare/genomics-error1-mfm..genomics-error1-somatic-mfm)