### PR TITLE
Remove abstract classes

### DIFF
--- a/FHIR-us-mcode.xml
+++ b/FHIR-us-mcode.xml
@@ -18,7 +18,7 @@
 <artifact id="ValueSet/ctcae-grade-value-set" key="ValueSet-ctcae-grade-value-set" name="CTCAE Grade Value Set"/>
 <artifact id="ValueSet/ctcae-preferred-term-value-set" key="ValueSet-ctcae-preferred-term-value-set" name="CTCAE Preferred Terms"/>
 <artifact id="ValueSet/mcode-cancer-body-location-vs" key="cancer-body-location-value-set" name="Cancer Body Location Value Set"/>
-<artifact id="StructureDefinition/mcode-cancer-condition-parent" key="cancer-condition-parent" name="Cancer Condition Parent"/>
+<artifact deprecated="true" id="Profile/mcode-cancer-condition-parent" key="cancer-condition-parent" name="Cancer Condition Parent"/>
 <artifact id="StructureDefinition/mcode-cancer-disease-status" key="cancer-disease-status" name="Cancer Disease Status"/>
 <artifact id="ValueSet/mcode-cancer-disease-status-evidence-type-vs" key="cancer-disease-status-evidence-type-value-set" name="Cancer Disease Status Evidence Type Value Set"/>
 <artifact id="ValueSet/mcode-cancer-disorder-vs" key="cancer-disorder-value-set" name="Cancer Disorder Value Set"/>
@@ -29,11 +29,10 @@
 <artifact deprecated="true" id="Profile/mcode-cancer-related-radiation-procedure" key="cancer-related-radiation-procedure" name="Cancer Related Radiation Procedure"/>
 <artifact deprecated="true" id="Profile/mcode-cancer-related-surgical-procedure" key="cancer-related-surgical-procedure" name="Cancer Related Surgical Procedure"/>
 <artifact deprecated="true" id="ValueSet/mcode-cancer-related-surgical-procedure-value-set" key="cancer-related-surgical-procedure-value-set" name="Cancer Related Surgical Procedure Value Set"/>
-<artifact id="StructureDefinition/mcode-cancer-stage-parent" key="cancer-stage-parent" name="Cancer Stage Parent"/>
+<artifact deprecated="true" id="Profile/mcode-cancer-stage-parent" key="cancer-stage-parent" name="Cancer Stage Parent"/>
 <artifact id="ValueSet/mcode-cancer-staging-system-vs" key="cancer-staging-system-value-set" name="Cancer Staging System Value Set"/>
 <artifact id="StructureDefinition/mcode-cancer-related-comorbidities" key="StructureDefinition-mcode-cancer-related-comorbidities" name="Cancer-Related Comorbidities"/>
 <artifact id="StructureDefinition/mcode-cancer-related-medication-request" key="StructureDefinition-mcode-cancer-related-medication-request" name="Cancer-Related Medication Request"/>
-<artifact id="StructureDefinition/mcode-cancer-related-procedure-parent" key="StructureDefinition-mcode-cancer-related-procedure-parent" name="Cancer-Related Procedure Parent"/>
 <artifact id="StructureDefinition/mcode-cancer-related-radiation-procedure" key="StructureDefinition-mcode-cancer-related-radiation-procedure" name="Cancer-Related Radiation Procedure"/>
 <artifact id="StructureDefinition/mcode-cancer-related-surgical-procedure" key="StructureDefinition-mcode-cancer-related-surgical-procedure" name="Cancer-Related Surgical Procedure"/>
 <artifact id="ValueSet/mcode-cancer-related-surgical-procedure-vs" key="ValueSet-mcode-cancer-related-surgical-procedure-vs" name="Cancer-Related Surgical Procedure Value Set"/>
@@ -98,7 +97,6 @@
 <artifact deprecated="true" key="Observation" name="Observation"/>
 <artifact id="OperationDefinition/mcode-patient-everything" key="OperationDefinition-mcode-patient-everything" name="Operation-mcode-patient-everything"/>
 <artifact id="CodeSystem/mcode-other-specify-code-system" key="CodeSystem-mcode-other-specify-code-system" name="Other Specify Code System"/>
-<artifact id="StructureDefinition/mcode-performance-status-parent" key="StructureDefinition-mcode-performance-status-parent" name="Performance Status Parent"/>
 <artifact id="ValueSet/mcode-present-absent-unknown" key="ValueSet-mcode-present-absent-unknown" name="Present-Absent-Unknown"/>
 <artifact id="StructureDefinition/mcode-primary-cancer-condition" key="primary-cancer-condition" name="Primary Cancer Condition"/>
 <artifact id="ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs" key="primary-or-uncertain-behavior-cancer-disorder-value-set" name="Primary or Uncertain Behavior Cancer Disorder Value Set"/>

--- a/input-cache/txcache/loinc.cache
+++ b/input-cache/txcache/loinc.cache
@@ -31478,3 +31478,139 @@ e: {
   "error" : ""
 }
 -------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://loinc.org",
+  "code" : "21901-4"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://loinc.org"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"false", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Distant metastases.pathology [Class] Cancer",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://loinc.org",
+  "code" : "21901-4"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://loinc.org"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
+v: {
+  "display" : "Distant metastases.pathology [Class] Cancer",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://loinc.org",
+  "code" : "21899-0"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://loinc.org"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"false", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Primary tumor.pathology Cancer",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://loinc.org",
+  "code" : "21899-0"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://loinc.org"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
+v: {
+  "display" : "Primary tumor.pathology Cancer",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://loinc.org",
+  "code" : "21900-6"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://loinc.org"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"false", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Regional lymph nodes.pathology [Class] Cancer",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://loinc.org",
+  "code" : "21900-6"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://loinc.org"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
+v: {
+  "display" : "Regional lymph nodes.pathology [Class] Cancer",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://loinc.org",
+  "code" : "21902-2"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://loinc.org"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"false", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Stage group.pathology Cancer",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://loinc.org",
+  "code" : "21902-2"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://loinc.org"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
+v: {
+  "display" : "Stage group.pathology Cancer",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------

--- a/input/fsh/SD_ComorbidCondition.fsh
+++ b/input/fsh/SD_ComorbidCondition.fsh
@@ -4,7 +4,7 @@ Id: mcode-comorbidities-parent
 Title: "Comorbidities Parent"
 Description: "General structure for capturing comorbid conditions with respect to a primary condition. The specific set of comorbidities of interest in a given context are defined by slicing the components array."
 * ^abstract = true
-* focus only Reference(Condition)  // the index condition
+* focus only Reference(Condition)  // the index condition, i.e. the context of the assessment of comorbidities
 * focus ^short = "Index Condition"
 * focus ^definition = "The comorbid conditions may be defined with respect to a particular condition. For example, the CDC has a list of comorbid conditions important to COVID-19. In this case, the focus would be COVID-19 and the comorbid condition categories would be those called out by CDC, namely obesity, renal disease, respiratory disease, etc."
 * component.value[x] only CodeableConcept
@@ -20,11 +20,10 @@ Id: mcode-cancer-related-comorbidities
 Title: "Cancer-Related Comorbidities"
 Description: "Comorbid conditions for a cancer condition, using Elixhauser comorbidity categories."
 * ^abstract = false
-* focus and component and component.extension MS
 * focus only Reference(PrimaryCancerCondition)
-* insert ObservationComponentSlicingRules
 * code = LNC#78923-0  // Comorbid condition panel
 * focus and component and component.extension[conditionReference] and component.extension[conditionCode] and component.extension[conditionReference] MS
+* insert ObservationComponentSlicingRules
 * component contains 
     alcoholAbuse 0..1 and
     cardiacArrhythmia 0..1 and

--- a/input/fsh/SD_ComorbidCondition.fsh
+++ b/input/fsh/SD_ComorbidCondition.fsh
@@ -4,8 +4,9 @@ Id: mcode-comorbidities-parent
 Title: "Comorbidities Parent"
 Description: "General structure for capturing comorbid conditions with respect to a primary condition. The specific set of comorbidities of interest in a given context are defined by slicing the components array."
 * ^abstract = true
-* focus only Reference(Condition)
-* code = LNC#78923-0  // Comorbid condition panel
+* focus only Reference(Condition)  // the index condition
+* focus ^short = "Index Condition"
+* focus ^definition = "The comorbid conditions may be defined with respect to a particular condition. For example, the CDC has a list of comorbid conditions important to COVID-19. In this case, the focus would be COVID-19 and the comorbid condition categories would be those called out by CDC, namely obesity, renal disease, respiratory disease, etc."
 * component.value[x] only CodeableConcept
 * component.value[x] from PresentAbsentUnknownVS (required)
 * component.extension contains 
@@ -22,6 +23,7 @@ Description: "Comorbid conditions for a cancer condition, using Elixhauser comor
 * focus and component and component.extension MS
 * focus only Reference(PrimaryCancerCondition)
 * insert ObservationComponentSlicingRules
+* code = LNC#78923-0  // Comorbid condition panel
 * focus and component and component.extension[conditionReference] and component.extension[conditionCode] and component.extension[conditionReference] MS
 * component contains 
     alcoholAbuse 0..1 and

--- a/input/fsh/SD_Condition.fsh
+++ b/input/fsh/SD_Condition.fsh
@@ -1,11 +1,6 @@
 Alias: AssertedDate = http://hl7.org/fhir/StructureDefinition/condition-assertedDate
 
-Profile: CancerConditionParent
-Parent:  USCoreCondition
-Id: mcode-cancer-condition-parent
-Title: "Cancer Condition Parent"
-Description:  "Abstract parent class for describing a primary or secondary metastatic neoplastic diseases, or individual tumors."
-* ^abstract = true
+RuleSet: CancerConditionCommonRules
 * extension contains
     AssertedDate named assertedDate 0..1 and
     HistologyMorphologyBehavior named histologyMorphologyBehavior 0..1
@@ -21,7 +16,7 @@ Description:  "Abstract parent class for describing a primary or secondary metas
 Profile: PrimaryCancerCondition
 Id: mcode-primary-cancer-condition
 Title: "Primary Cancer Condition"
-Parent: CancerConditionParent
+Parent: USCoreCondition
 Description: "Records the the primary cancer condition, the original or first tumor in the body (Definition from: [NCI Dictionary of Cancer Terms](https://www.cancer.gov/publications/dictionaries/cancer-terms/def/primary-tumor)). Cancers that are not clearly secondary (i.e., of uncertain origin or behavior) should be documented as primary.
 
 Cancer staging information summarized in this profile should reflect the most recent staging assessment on the patient, and should be updated if and when there is a new staging assessment. Past staging assessments will be preserved in instances of the TNMClinicalStageGroup and/or TNMPathologicalStageGroup, which refer back to PrimaryCancerCondition.
@@ -30,10 +25,10 @@ Conformance statement:
 
 Condition resources associated with an mCODE patient with a Condition.code in the value set PrimaryOrUncertainBehaviorCancerDisorderVS MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form, for example, when employing a code that extends the PrimaryOrUncertainBehaviorCancerDisorderVS value set. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly."
 
-* ^abstract = false
+* insert CancerConditionCommonRules
 * code from PrimaryOrUncertainBehaviorCancerDisorderVS (required)
 * code obeys primary-cancer-condition-code-invariant
-* stage.assessment only Reference(CancerStageParent)
+* stage.assessment only Reference(TNMClinicalStageGroup or TNMClinicalPrimaryTumorCategory or TNMClinicalRegionalNodesCategory or TNMClinicalDistantMetastasesCategory or TNMPathologicalStageGroup or TNMPathologicalPrimaryTumorCategory or TNMPathologicalRegionalNodesCategory or TNMPathologicalDistantMetastasesCategory)
 
 Invariant: primary-cancer-condition-code-invariant
 Description: "If the code representing 'Other primary cancer condition, specify' is used, a second code from outside the original value set must be present."
@@ -41,7 +36,7 @@ Expression: "coding.where(code = 'OtherPrimaryCancerCondition').exists() implies
 Severity: #error
 
 Profile: SecondaryCancerCondition
-Parent: CancerConditionParent
+Parent: USCoreCondition
 Id: mcode-secondary-cancer-condition
 Title: "Secondary Cancer Condition"
 Description: "Records the history of secondary neoplasms, including location(s) and the date of onset of metastases. A secondary cancer results from the spread (metastasization) of cancer from its original site (Definition from: NCI Dictionary of Cancer Terms).
@@ -50,7 +45,7 @@ Conformance statement:
 
 Condition resources associated with an mCODE patient with a Condition.code in the value set SecondaryCancerDisorderVS MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form, for example, when employing a code that extends the SecondaryCancerDisorderVS value set. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly."
 
-* ^abstract = false
+* insert CancerConditionCommonRules
 * extension contains RelatedPrimaryCancerCondition named relatedPrimaryCancerCondition 0..1 MS
 * code from SecondaryCancerDisorderVS (required)
 * code obeys secondary-cancer-condition-code-invariant

--- a/input/fsh/SD_Genomics.fsh
+++ b/input/fsh/SD_Genomics.fsh
@@ -101,7 +101,7 @@ Observation resources associated with an mCODE patient with Observation.code LOI
 Profile:        TumorMarkerTest
 Parent:         USCoreObservationLab
 Id:             mcode-tumor-marker-test
-Title:          "Tumor Marker"
+Title:          "Tumor Marker Test"
 Description:    "The result of a tumor marker test. Tumor marker tests are generally used to guide cancer treatment decisions and monitor treatment, as well as to predict the chance of recovery and cancer recurrence. A tumor marker is a substance found in tissue or blood or other body fluids that may be a sign of cancer or certain benign (noncancer) conditions. Most tumor markers are made by both normal cells and cancer cells, but they are made in larger amounts by cancer cells. A tumor marker may help to diagnose cancer, plan treatment, or find out how well treatment is working or if cancer has come back. Examples of tumor markers include CA-125 (in ovarian cancer), CA 15-3 (in breast cancer), CEA (in colon cancer), and PSA (in prostate cancer). Tumor markers differ from genetic markers in that they are measured at the levels of the protein and substance post-RNA protein synthesis. (Definition adapted from: [NCI Dictionary of Cancer Terms](https://www.cancer.gov/publications/dictionaries/cancer-terms/def/tumor-marker-test) and [Cancer.Net](https://www.cancer.net/navigating-cancer-care/diagnosing-cancer/tests-and-procedures/tumor-marker-tests)).
 
 Conformance statement:

--- a/input/fsh/SD_PerformanceStatus.fsh
+++ b/input/fsh/SD_PerformanceStatus.fsh
@@ -1,5 +1,5 @@
 RuleSet: PerformanceStatusCommonRules
-* status and code and subject and effective[x] and valueInteger MS
+* status and code and subject and effective[x] and value[x] and interpretation MS
 * insert CategorySlicingRules
 * category = ObsCat#survey
 * subject 1..1
@@ -13,7 +13,7 @@ RuleSet: PerformanceStatusCommonRules
 * subject only Reference(USCorePatient)
 * effective[x] only dateTime or Period
 * performer only Reference(Practitioner)
-* value[x] only integer
+
 
 Profile:    KarnofskyPerformanceStatus
 Parent:     Observation

--- a/input/fsh/SD_PerformanceStatus.fsh
+++ b/input/fsh/SD_PerformanceStatus.fsh
@@ -1,9 +1,4 @@
-Profile: PerformanceStatusParent
-Parent:  Observation
-Id:      mcode-performance-status-parent
-Title:      "Performance Status Parent"
-Description:    "Abstract parent class for performance status profiles."
-* ^abstract = true
+RuleSet: PerformanceStatusCommonRules
 * status and code and subject and effective[x] and valueInteger MS
 * insert CategorySlicingRules
 * category = ObsCat#survey
@@ -21,7 +16,7 @@ Description:    "Abstract parent class for performance status profiles."
 * value[x] only integer
 
 Profile:    KarnofskyPerformanceStatus
-Parent:     PerformanceStatusParent
+Parent:     Observation
 Id:         mcode-karnofsky-performance-status
 Title:      "Karnofsky Performance Status"
 Description:    "The Karnofsky Performance Status (KPS) is a tool used to measure a patient's functional status. It can be used to compare the effectiveness of different therapies and to help assess the prognosis of certain patients, such as those with certain cancers. The KPS score ranges from 0 to 100 in intervals of 10. Higher scores are associated with better functional status, with 100 representing no symptoms or evidence of disease, and 0 representing death.
@@ -29,13 +24,13 @@ Description:    "The Karnofsky Performance Status (KPS) is a tool used to measur
 Conformance statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 89243-0 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
-* ^abstract = false
+* insert PerformanceStatusCommonRules
 * code = LNC#89243-0 //"Karnofsky Performance Status score"
 * value[x] only integer
 * interpretation from http://loinc.org/vs/LL4986-7 (required)
 
 Profile:    ECOGPerformanceStatus
-Parent:     PerformanceStatusParent
+Parent:     Observation
 Id:         mcode-ecog-performance-status
 Title:      "ECOG Performance Status"
 Description:    "The Eastern Cooperative Oncology Group (ECOG) Performance Status represents the patient's functional status and is used to determine their ability to tolerate therapies in serious illness, specifically for chemotherapy. (Definition from: [LOINC](https://loinc.org/89262-0/))
@@ -43,7 +38,7 @@ Description:    "The Eastern Cooperative Oncology Group (ECOG) Performance Statu
 Conformance statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 89247-1 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
-* ^abstract = false
+* insert PerformanceStatusCommonRules
 * code = LNC#89247-1 //"ECOG Performance Status score"
 * value[x] only integer
 * interpretation from http://loinc.org/vs/LL529-9 (required)

--- a/input/fsh/SD_Procedures.fsh
+++ b/input/fsh/SD_Procedures.fsh
@@ -1,9 +1,4 @@
-Profile: CancerRelatedProcedureParent
-Parent: USCoreProcedure
-Id:     mcode-cancer-related-procedure-parent
-Title:  "Cancer-Related Procedure Parent"
-Description: "Abstract parent class for cancer procedure profiles."
-* ^abstract = true
+RuleSet: CancerRelatedProcedureCommonRuleSet
 * obeys mcode-reason-required
 * extension contains
     TreatmentIntent named treatmentIntent 0..1 MS
@@ -19,7 +14,7 @@ Description: "Abstract parent class for cancer procedure profiles."
 
 
 Profile:  CancerRelatedRadiationProcedure
-Parent:   CancerRelatedProcedureParent
+Parent:   USCoreProcedure
 Id:       mcode-cancer-related-radiation-procedure
 Title:    "Cancer-Related Radiation Procedure"
 Description: "A radiological treatment addressing a cancer condition. The scope of this profile has been narrowed to cancer-related procedures by constraining the reasonReference and reasonCode to cancer conditions, one of which is required.
@@ -27,7 +22,7 @@ Description: "A radiological treatment addressing a cancer condition. The scope 
 Conformance statement:
 
 Procedure resources associated with an mCODE patient with Procedure.category SNOMED-CT 53438000 MAY conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form. Specifically, we expect that any radiation therapy related to the treatment of a `PrimaryCancerCondition` or `SecondaryCancerCondition` would be published in this form."
-* ^abstract = false
+* insert CancerRelatedProcedureCommonRuleSet
 // Do not insert the category slicing rules because Procedure.category is 0..1. 
 * category = SCT#53438000 //"Radiation therapy procedure or service (procedure)"
 * code from RadiationProcedureVS (extensible)
@@ -36,7 +31,7 @@ Procedure resources associated with an mCODE patient with Procedure.category SNO
 
 
 Profile:  CancerRelatedSurgicalProcedure
-Parent:   CancerRelatedProcedureParent
+Parent:   USCoreProcedure
 Id:       mcode-cancer-related-surgical-procedure
 Title:    "Cancer-Related Surgical Procedure"
 Description: "A surgical action addressing a cancer condition. The scope of this profile has been narrowed to cancer-related procedures by constraining the reasonReference and reasonCode to cancer conditions, one of which is required.
@@ -44,7 +39,7 @@ Description: "A surgical action addressing a cancer condition. The scope of this
 Conformance statement:
 
 Procedure resources associated with an mCODE patient with Procedure.category SNOMED-CT 387713003 MAY conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form. Specifically, we expect that any surgical procedure related to the treatment of a `PrimaryCancerCondition` or `SecondaryCancerCondition` would be published in this form."
-* ^abstract = false
+* insert CancerRelatedProcedureCommonRuleSet
 // Do not insert the category slicing rules because Procedure.category is 0..1.
 * category = SCT#387713003 //"Surgical procedure"
 * code from CancerRelatedSurgicalProcedureVS (extensible)

--- a/input/fsh/SD_Staging.fsh
+++ b/input/fsh/SD_Staging.fsh
@@ -1,9 +1,4 @@
-Profile: CancerStageParent
-Id: mcode-cancer-stage-parent
-Parent: Observation
-Title: "Cancer Stage Parent"
-Description:  "Abstract parent class for members of cancer staging panels. Cancer panel members must include a timing element and staging system, and focus on a cancer disorder. Specific realizations will have value sets specific to certain staging systems."
-* ^abstract = true
+RuleSet: CancerStageCommonRules
 * status and code and subject and effective[x] and value[x] and method and focus MS
 * value[x] only CodeableConcept
 * value[x] ^comment = ""    // suppress QA error on #notes link
@@ -22,14 +17,14 @@ Description:  "Abstract parent class for members of cancer staging panels. Cance
 
 Profile: TNMClinicalStageGroup
 Id: mcode-tnm-clinical-stage-group
-Parent: CancerStageParent
+Parent: Observation
 Title: "TNM Clinical Stage Group"
 Description: "The extent of the cancer in the body, according to the TNM classification system, based on evidence such as physical examination, imaging, and/or biopsy.
 
 Conformance Statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 21908-9 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
-* ^abstract = false
+* insert CancerStageCommonRules
 * hasMember MS
 * code = LNC#21908-9 //"Stage group.clinical Cancer"
 * value[x] from TNMStageGroupVS (preferred)
@@ -56,14 +51,14 @@ Observation resources associated with an mCODE patient with Observation.code LOI
 
 Profile:  TNMClinicalPrimaryTumorCategory
 Id: mcode-tnm-clinical-primary-tumor-category
-Parent: CancerStageParent
+Parent: Observation
 Title: "TNM Clinical Primary Tumor Category"
 Description: "Category of the primary tumor, based on its size and extent, based on evidence such as physical examination, imaging, and/or biopsy.
 
 Conformance Statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 21905-5 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
-* ^abstract = false
+* insert CancerStageCommonRules
 * code = LNC#21905-5 //"Primary tumor.clinical [Class] Cancer"
 * insert CategorySlicingRules
 * category = ObsCat#exam "exam"
@@ -71,14 +66,14 @@ Observation resources associated with an mCODE patient with Observation.code LOI
 
 Profile:  TNMClinicalRegionalNodesCategory
 Id: mcode-tnm-clinical-regional-nodes-category
-Parent: CancerStageParent
+Parent: Observation
 Title: "TNM Clinical Regional Nodes Category"
 Description: "Category of the presence or absence of metastases in regional lymph nodes, based on evidence such as physical examination, imaging, and/or biopsy.
 
 Conformance Statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 21906-3 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
-* ^abstract = false
+* insert CancerStageCommonRules
 * code = LNC#21906-3 //"Regional lymph nodes.clinical [Class] Cancer"
 * insert CategorySlicingRules
 * category = ObsCat#exam "exam"
@@ -86,14 +81,14 @@ Observation resources associated with an mCODE patient with Observation.code LOI
 
 Profile:  TNMClinicalDistantMetastasesCategory
 Id: mcode-tnm-clinical-distant-metastases-category
-Parent: CancerStageParent
+Parent: Observation
 Title: "TNM Clinical Distant Metastases Category"
 Description: "Category describing the extent of a tumor metastasis in remote anatomical locations, based on evidence such as physical examination, imaging, and/or biopsy.
 
 Conformance Statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 21907-1 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
-* ^abstract = false
+* insert CancerStageCommonRules
 * code = LNC#21907-1 //"Distant metastases.clinical [Class] Cancer"
 * insert CategorySlicingRules
 * category = ObsCat#exam "exam"
@@ -103,18 +98,16 @@ Observation resources associated with an mCODE patient with Observation.code LOI
 
 Profile: TNMPathologicalStageGroup
 Id: mcode-tnm-pathological-stage-group
-Parent: CancerStageParent
+Parent: USCoreObservationLab
 Title: "TNM Pathological Stage Group"
 Description: "The extent of the cancer in the body, according to the TNM classification system, assessed through pathologic analysis of a specimen.
 
 Conformance Statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 21902-2 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
-* ^abstract = false
+* insert CancerStageCommonRules
 * hasMember MS
 * code =  LNC#21902-2 //"Stage group.pathology Cancer"
-* insert CategorySlicingRules
-* category = ObsCat#laboratory "laboratory"
 * value[x] from TNMStageGroupVS (preferred)
 * insert ObservationHasMemberSlicingRules
 * hasMember contains
@@ -137,45 +130,39 @@ Observation resources associated with an mCODE patient with Observation.code LOI
 
 Profile:  TNMPathologicalPrimaryTumorCategory
 Id: mcode-tnm-pathological-primary-tumor-category
-Parent: CancerStageParent
+Parent: USCoreObservationLab
 Title: "TNM Pathological Primary Tumor Category"
 Description: "Category of the primary tumor, based on its size and extent, assessed through pathologic analysis of a specimen.
 
 Conformance Statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 21899-0 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
-* ^abstract = false
+* insert CancerStageCommonRules
 * code = LNC#21899-0 //"Primary tumor.pathology Cancer"
-* insert CategorySlicingRules
-* category = ObsCat#laboratory "laboratory"
 * value[x] from TNMPrimaryTumorCategoryVS (preferred)
 
 Profile:  TNMPathologicalRegionalNodesCategory
 Id: mcode-tnm-pathological-regional-nodes-category
-Parent: CancerStageParent
+Parent: USCoreObservationLab
 Title: "TNM Pathological Regional Nodes Category"
 Description: "Category of the presence or absence of metastases in regional lymph nodes, assessed through pathologic analysis of a specimen.
 
 Conformance Statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 21900-6 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
-* ^abstract = false
+* insert CancerStageCommonRules
 * code = LNC#21900-6 //"Regional lymph nodes.pathology [Class] Cancer"
-* insert CategorySlicingRules
-* category = ObsCat#laboratory "laboratory"
 * value[x] from TNMRegionalNodesCategoryVS (preferred)
 
 Profile:  TNMPathologicalDistantMetastasesCategory
 Id: mcode-tnm-pathological-distant-metastases-category
-Parent: CancerStageParent
+Parent: USCoreObservationLab
 Title: "TNM Pathological Distant Metastases Category"
 Description: "Category describing the presence or absence of metastases in remote anatomical locations, assessed through pathologic analysis of a specimen.
 
 Conformance Statement:
 
 Observation resources associated with an mCODE patient with Observation.code LOINC 21901-4 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form."
-* ^abstract = false
+* insert CancerStageCommonRules
 * code = LNC#21901-4 //"Distant metastases.pathology [Class] Cancer"
-* insert CategorySlicingRules
-* category = ObsCat#laboratory "laboratory"
 * value[x] from TNMDistantMetastasesCategoryVS (preferred)

--- a/input/pagecontent/implementation.md
+++ b/input/pagecontent/implementation.md
@@ -13,7 +13,7 @@ This page contains miscellaneous information on modeling and FHIR implementation
 
 The mCODE Implementation Guide was developed using the standard HL7 FHIR publishing tools. The page layouts and symbols are explained [in the FHIR documentation](https://www.hl7.org/fhir/formats.html).
 
-Each profile is shown in multiple views. The "Differential Table" view represents the difference between the current profile and its immediate parent. When interpreting this view, bear in mind that the immediate parent is typically not the base FHIR resource, but it could be a US Core profile or another profile in this guide. The parent is shown as the "Type" in the first line of the Differential Table view. For example, for [ECOG Performance Status](StructureDefinition-mcode-ecog-performance-status.html) the immediate parent is [PerformanceStatusParent](StructureDefinition-mcode-performance-status-parent.html), whose parent is Observation. The "sum" of these two differentials represent the difference between ECOG Performance Status and the base resource, Observation.
+Each profile is shown in multiple views. The "Differential Table" view represents the difference between the current profile and its base resource or profile. When interpreting this view, bear in mind that the immediate parent may not be a base FHIR resource, but it could be a US Core profile or another profile in this guide.
 
 #### Terminology Preferences
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -109,12 +109,7 @@ groups:
     name: Abstract Profiles
     description: These are profiles on resources or data types that describe patterns used by other profiles, but cannot be instantiated directly. I.e. instances can conform to profiles based on these abstract profiles, but do not declare conformance to the abstract profiles themselves.
     resources:
-      - StructureDefinition/mcode-cancer-condition-parent
-      - StructureDefinition/mcode-cancer-related-procedure-parent
-      - StructureDefinition/mcode-cancer-stage-parent
       - StructureDefinition/mcode-comorbidities-parent
-      - StructureDefinition/mcode-performance-status-parent
-
 
   # Extensions
   Extensions:


### PR DESCRIPTION
Replaced all but one abstract class with rule sets, so the diffs make more sense to the reader, and there are not a bunch of extra confusing abstract profiles. 
I haven't found a method to remove the comorbid condition parent class because something about extending Observation.component and then slicing it doesn't seem to work without the abstract parent. 