### PR TITLE
Removed unnecessary rules in examples

### DIFF
--- a/FHIR-us-mcode.xml
+++ b/FHIR-us-mcode.xml
@@ -95,7 +95,6 @@
 <artifact id="ValueSet/mcode-location-qualifier-vs" key="ValueSet-mcode-location-qualifier-vs" name="Location Qualifier Value Set"/>
 <artifact id="ValueSet/mcode-tumor-size-method-vs" key="ValueSet-mcode-tumor-size-method-vs" name="Methods for measuring tumor size"/>
 <artifact deprecated="true" key="Observation" name="Observation"/>
-<artifact id="OperationDefinition/mcode-patient-everything" key="OperationDefinition-mcode-patient-everything" name="Operation-mcode-patient-everything"/>
 <artifact id="CodeSystem/mcode-other-specify-code-system" key="CodeSystem-mcode-other-specify-code-system" name="Other Specify Code System"/>
 <artifact id="ValueSet/mcode-present-absent-unknown" key="ValueSet-mcode-present-absent-unknown" name="Present-Absent-Unknown"/>
 <artifact id="StructureDefinition/mcode-primary-cancer-condition" key="primary-cancer-condition" name="Primary Cancer Condition"/>
@@ -198,6 +197,7 @@
 <artifact id="Observation/mCODETNMPathologicalStageGroupExample1" key="Observation-mCODETNMPathologicalStageGroupExample1" name="mCODETNMPathologicalStageGroupExample1"/>
 <artifact deprecated="true" id="Example/mcode-tumor-marker-example-01" key="mcode-tumor-marker-example-01" name="mCODETumorMarkerExample01"/>
 <artifact id="Observation/mCODETumorMarkerTestExample1" key="Observation-mCODETumorMarkerTestExample1" name="mCODETumorMarkerTestExample1"/>
+<artifact id="OperationDefinition/mcode-patient-everything" key="OperationDefinition-mcode-patient-everything" name="mcode-patient-everything"/>
 <artifact id="CapabilityStatement/mcode-receiver-cancer-conditions-then-patients" key="CapabilityStatement-mcode-receiver-cancer-conditions-then-patients" name="mcode-receiver-cancer-conditions-then-patients"/>
 <artifact id="CapabilityStatement/mcode-receiver-patient-bundle" key="CapabilityStatement-mcode-receiver-patient-bundle" name="mcode-receiver-patient-bundle"/>
 <artifact id="CapabilityStatement/mcode-receiver-patients-and-cancer-conditions" key="CapabilityStatement-mcode-receiver-patients-and-cancer-conditions" name="mcode-receiver-patients-and-cancer-conditions"/>

--- a/input/fsh/DEF_Operations.fsh
+++ b/input/fsh/DEF_Operations.fsh
@@ -1,9 +1,8 @@
-Instance: Operation-mcode-patient-everything
+Instance: mcode-patient-everything
 InstanceOf: OperationDefinition
 Description: "Gets an [mCODE Patient Bundle](StructureDefinition-mcode-patient-bundle.html) for a specific patient that contains all of that patient's resources that conform to mCODE Profiles."
 Usage: #definition
 
-* id = "mcode-patient-everything"
 * name = "Fetch_mCODE_patient_bundle"
 * title = "Fetch mCODE Patient Bundle for a given Patient"
 * status = #draft

--- a/input/fsh/EX_AdverseEvent.fsh
+++ b/input/fsh/EX_AdverseEvent.fsh
@@ -1,9 +1,7 @@
 Instance: ctc-adverse-event-example-1
 InstanceOf: CTCAdverseEvent
 Description: "Grade 2 dehydration attributed to gefitinib"
-* id = "ctc-adverse-event-example-1"
 * contained[0] = mcode-medication-example-1
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/ctc-adverse-event"
 * subject = Reference(Patient/mCODEPatientExample1)
 * event = NCIT#C57787  "Dehydration"
 * event.text = "DHN IV given"
@@ -20,8 +18,6 @@ Description: "Grade 2 dehydration attributed to gefitinib"
 Instance: ctc-adverse-event-example-2
 InstanceOf: CTCAdverseEvent
 Description: "Non-occurrence of anemia"
-* id = "ctc-adverse-event-example-2"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/ctc-adverse-event"
 * subject = Reference(Patient/mCODEPatientExample1)
 * event = NCIT#C143283  "Anemia"
 * event.text = "AIHA NGTD"
@@ -32,5 +28,4 @@ Instance: mcode-medication-example-1
 InstanceOf: Medication
 Description: "Gefitinib 250 MG Oral Tablet"
 Usage: #inline
-* id = "mcode-medication-example-1"
 * code = RXN#349472 "gefitinib 250 MG Oral Tablet"

--- a/input/fsh/EX_Example1.fsh
+++ b/input/fsh/EX_Example1.fsh
@@ -1,8 +1,6 @@
 Instance: mCODEPrimaryCancerConditionExample1
 InstanceOf: PrimaryCancerCondition
 Description: "mCODE Example for Primary Cancer Condition"
-* id = "mCODEPrimaryCancerConditionExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-primary-cancer-condition"
 * clinicalStatus = ClinStatus#active "Active"
 * verificationStatus = VerStatus#confirmed "Confirmed"
 * category = CondCat#problem-list-item
@@ -19,8 +17,6 @@ Description: "mCODE Example for Primary Cancer Condition"
 Instance: mCODESecondaryCancerConditionExample1
 InstanceOf: SecondaryCancerCondition
 Description: "mCODE Example for Secondary Cancer Condition"
-* id = "mCODESecondaryCancerConditionExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-secondary-cancer-condition"
 * extension[relatedPrimaryCancerCondition].valueReference = Reference(mCODEPrimaryCancerConditionExample1)
 * clinicalStatus = ClinStatus#active "Active"
 * verificationStatus = VerStatus#confirmed "Confirmed"
@@ -33,8 +29,6 @@ Description: "mCODE Example for Secondary Cancer Condition"
 Instance: mCODECancerDiseaseStatusExample1
 InstanceOf: CancerDiseaseStatus
 Description: "mCODE Example for Cancer Disease Status"
-* id = "mCODECancerDiseaseStatusExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
 // * extension[evidenceType].url = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type"
 * extension[evidenceType].valueCodeableConcept = SCT#108257001 "Anatomic pathology procedure (procedure)"
 * status = #final "final"
@@ -46,8 +40,6 @@ Description: "mCODE Example for Cancer Disease Status"
 Instance: mCODECancerRelatedComorbiditiesExample1
 InstanceOf: CancerRelatedComorbidities
 Description: "mCODE Example for Cancer-Related Comorbidities"
-* id = "mCODECancerRelatedComorbiditiesExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-comorbidities"
 * subject = Reference(mCODEPatientExample1)
 * performer = Reference(mCODEPractitionerExample1)
 * status = #final "final"
@@ -73,8 +65,6 @@ Description: "mCODE Example for Cancer-Related Comorbidities"
 Instance: mCODEPatientExample1
 InstanceOf: CancerPatient
 Description: "mCODE Example for Patient"
-* id = "mCODEPatientExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient"
 * identifier.use = #usual
 * identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
 * identifier.system = "http://hospital.example.org"
@@ -99,8 +89,6 @@ Description: "mCODE Example for Patient"
 Instance: mCODEPatientExample2
 InstanceOf: CancerPatient
 Description: "mCODE Example for Patient"
-* id = "mCODEPatientExample2"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient"
 // The following lines must use the slice names, not the defining URLs
 // * extension[race].url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
 // * extension[race].extension[ombCategory].url = "ombCategory"
@@ -133,7 +121,6 @@ Description: "mCODE Example for Patient"
 Instance: mCODEOrganizationExample1
 InstanceOf: USCoreOrganization
 Description: "mCODE Example for Organization"
-* id = "mCODEOrganizationExample1"
 * identifier[NPI].value = "1265714091"
 * active = true
 * name = "Foundation Medicine"
@@ -148,7 +135,6 @@ Description: "mCODE Example for Organization"
 Instance: mCODEPractitionerExample1
 InstanceOf: USCorePractitioner
 Description: "mCODE Example for Practitioner"
-* id = "mCODEPractitionerExample1"
 * identifier[NPI].value = "9988776655"
 * name.family = "Anydoc"
 * name.given = "Kyle"
@@ -165,7 +151,6 @@ Description: "mCODE Example for Practitioner"
 Instance: mCODEDepressionExample1
 InstanceOf: USCoreCondition
 Description: "mCODE Example of Depression (as Comorbid condition), part of mCODECancerRelatedComorbiditiesExample01"
-* id = "mCODEDepressionExample1"
 * subject = Reference(mCODEPatientExample1)
 * asserter = Reference(mCODEPractitionerExample1)
 * category = CondCat#problem-list-item
@@ -177,8 +162,6 @@ Description: "mCODE Example of Depression (as Comorbid condition), part of mCODE
 Instance: mCODEECOGPerformanceStatusExample1
 InstanceOf: ECOGPerformanceStatus
 Description: "mCODE Example for ECOG Performance Status"
-* id = "mCODEECOGPerformanceStatusExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-ecog-performance-status"
 * status = #final "final"
 * method = SCT#5880005 "Clinical examination"
 * subject = Reference(mCODEPatientExample1)
@@ -190,8 +173,6 @@ Description: "mCODE Example for ECOG Performance Status"
 Instance: mCODEKarnofskyPerformanceStatusExample1
 InstanceOf: KarnofskyPerformanceStatus
 Description: "mCODE Example for Karnofsky Performance Status"
-* id = "mCODEKarnofskyPerformanceStatusExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-karnofsky-performance-status"
 * status = #final "final"
 * method = SCT#5880005 "Clinical examination"
 * subject = Reference(mCODEPatientExample1)
@@ -203,8 +184,6 @@ Description: "mCODE Example for Karnofsky Performance Status"
 Instance: mCODECancerRelatedSurgicalProcedureExample1
 InstanceOf: CancerRelatedSurgicalProcedure
 Description: "mCODE Example for Cancer Related Surgical Procedure"
-* id = "mCODECancerRelatedSurgicalProcedureExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-surgical-procedure"
 * status = #completed "completed"
 * code = SCT#359615001 "Partial lobectomy of lung (procedure)"
 * subject = Reference(mCODEPatientExample1)
@@ -217,8 +196,6 @@ Description: "mCODE Example for Cancer Related Surgical Procedure"
 Instance: mCODECancerRelatedRadiationProcedureExample1
 InstanceOf: CancerRelatedRadiationProcedure
 Description: "mCODE Example for Cancer Related Radiation Procedure"
-* id = "mCODECancerRelatedRadiationProcedureExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-radiation-procedure"
 * status = #completed "completed"
 * code = SCT#152198000 "Brachytherapy (procedure)"
 * subject = Reference(mCODEPatientExample1)
@@ -233,8 +210,6 @@ Description: "mCODE Example for Cancer Related Radiation Procedure"
 Instance: mCODETNMClinicalStageGroupExample1
 InstanceOf: TNMClinicalStageGroup
 Description: "mCODE Example for TNM Clinical Stage Group"
-* id = "mCODETNMClinicalStageGroupExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-stage-group"
 * status = #final "final"
 * method = NCIT#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample1)
@@ -247,8 +222,6 @@ Description: "mCODE Example for TNM Clinical Stage Group"
 Instance: mCODETNMClinicalDistantMetastasesCategoryExample1
 InstanceOf: TNMClinicalDistantMetastasesCategory
 Description: "mCODE Example for TNM Clinical Distant Metastases Category"
-* id = "mCODETNMClinicalDistantMetastasesCategoryExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-distant-metastases-category"
 * status = #final "final"
 * method = NCIT#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample1)
@@ -258,8 +231,6 @@ Description: "mCODE Example for TNM Clinical Distant Metastases Category"
 Instance: mCODETNMClinicalPrimaryTumorCategoryExample1
 InstanceOf: TNMClinicalPrimaryTumorCategory
 Description: "mCODE Example for TNM Clinical Primary Tumor Category"
-* id = "mCODETNMClinicalPrimaryTumorCategoryExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-primary-tumor-category"
 * status = #final "final"
 * method = NCIT#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample1)
@@ -270,8 +241,6 @@ Description: "mCODE Example for TNM Clinical Primary Tumor Category"
 Instance: mCODETNMClinicalRegionalNodesCategoryExample1
 InstanceOf: TNMClinicalRegionalNodesCategory
 Description: "mCODE Example for TNM Clinical Regional Nodes Category"
-* id = "mCODETNMClinicalRegionalNodesCategoryExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-regional-nodes-category"
 * status = #final "final"
 * method = NCIT#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample1)
@@ -282,8 +251,6 @@ Description: "mCODE Example for TNM Clinical Regional Nodes Category"
 Instance: mCODETNMPathologicalStageGroupExample1
 InstanceOf: TNMPathologicalStageGroup
 Description: "mCODE Example for TNM Pathological Stage Group"
-* id = "mCODETNMPathologicalStageGroupExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-stage-group"
 * status = #final "final"
 * method = NCIT#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample1)
@@ -297,8 +264,6 @@ Description: "mCODE Example for TNM Pathological Stage Group"
 Instance: mCODETNMPathologicalDistantMetastasesCategoryExample1
 InstanceOf: TNMPathologicalDistantMetastasesCategory
 Description: "mCODE Example for TNM Pathological Distant Metastases Category"
-* id = "mCODETNMPathologicalDistantMetastasesCategoryExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-distant-metastases-category"
 * status = #final "final"
 * method = NCIT#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample1)
@@ -309,8 +274,6 @@ Description: "mCODE Example for TNM Pathological Distant Metastases Category"
 Instance: mCODETNMPathologicalPrimaryTumorCategoryExample1
 InstanceOf: TNMPathologicalPrimaryTumorCategory
 Description: "mCODE Example for TNM Pathological Primary Tumor Category"
-* id = "mCODETNMPathologicalPrimaryTumorCategoryExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-primary-tumor-category"
 * status = #final "final"
 * method = NCIT#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample1)
@@ -321,8 +284,6 @@ Description: "mCODE Example for TNM Pathological Primary Tumor Category"
 Instance: mCODETNMPathologicalRegionalNodesCategoryExample1
 InstanceOf: TNMPathologicalRegionalNodesCategory
 Description: "mCODE Example for TNM Pathological Regional Nodes Category"
-* id = "mCODETNMPathologicalRegionalNodesCategoryExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-regional-nodes-category"
 * status = #final "final"
 * method = NCIT#C146985 "AJCC Cancer Staging Manual 8th Edition"
 * subject = Reference(mCODEPatientExample1)
@@ -332,8 +293,6 @@ Description: "mCODE Example for TNM Pathological Regional Nodes Category"
 Instance: mCODECancerRelatedMedicationRequestExample1
 InstanceOf: CancerRelatedMedicationRequest
 Description: "mCODE Example for CancerRelatedMedicationRequest"
-* id = "mCODECancerRelatedMedicationRequestExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-request"
 * subject = Reference(mCODEPatientExample1)
 * status = MedReqStatus#active
 * intent = MedReqIntent#order
@@ -356,8 +315,6 @@ Description: "mCODE Example for CancerRelatedMedicationRequest"
 Instance: mCODECancerRelatedMedicationRequestExample2
 InstanceOf: CancerRelatedMedicationRequest
 Description: "mCODE Example for CancerRelatedMedicationRequest - Chemo Infusion"
-* id = "mCODECancerRelatedMedicationRequestExample2"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-request"
 * subject = Reference(mCODEPatientExample1)
 * status = MedReqStatus#active
 * intent = MedReqIntent#order
@@ -378,8 +335,6 @@ Description: "mCODE Example for CancerRelatedMedicationRequest - Chemo Infusion"
 Instance: mCODECancerRelatedMedicationAdministrationExample1
 InstanceOf: CancerRelatedMedicationAdministration
 Description: "mCODE Example for CancerRelatedMedicationAdministration"
-* id = "mCODECancerRelatedMedicationAdministrationExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-administration"
 * subject = Reference(mCODEPatientExample1)
 * status = MedAdminStatus#completed
 * category = MedAdminCategory#outpatient
@@ -395,8 +350,6 @@ Description: "mCODE Example for CancerRelatedMedicationAdministration"
 Instance: mCODECancerRelatedMedicationStatementExample1
 InstanceOf: CancerRelatedMedicationStatement
 Description: "mCODE Example for Cancer Related Medication Statement"
-* id = "mCODECancerRelatedMedicationStatementExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-statement"
 * status = MedStatus#active "active"
 * category = MedReqCat#community "community"
 * medicationCodeableConcept = RXN#349472 "gefitinib 250 MG Oral Tablet"
@@ -412,8 +365,6 @@ Description: "mCODE Example for Cancer Related Medication Statement"
 Instance: mCODECancerRelatedMedicationStatementExample2
 InstanceOf: CancerRelatedMedicationStatement
 Description: "mCODE Example for Cancer Related Medication Statement"
-* id = "mCODECancerRelatedMedicationStatementExample2"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-statement"
 * status = MedStatus#stopped "stopped"
 * category = MedReqCat#community "community"
 * medicationCodeableConcept = RXN#349472 "gefitinib 250 MG Oral Tablet"

--- a/input/fsh/EX_Example1_Genomics.fsh
+++ b/input/fsh/EX_Example1_Genomics.fsh
@@ -1,8 +1,6 @@
 Instance: mCODECancerGeneticVariantExample1
 InstanceOf: CancerGeneticVariant
 Description: "mCODE Example for Cancer Genetic Variant"
-* id = "mCODECancerGeneticVariantExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-genetic-variant"
 * status = #final "Final"
 * method = LNC#LA26398-0 "Sequencing"
 // value[x] has alternate codings depending on where to place the interpretation of "Positive or Negative".
@@ -26,8 +24,6 @@ Description: "mCODE Example for Cancer Genetic Variant"
 Instance: mCODECancerGeneticVariantExample2
 InstanceOf: CancerGeneticVariant
 Description: "mCODE Example for Cancer Genetic Variant"
-* id = "mCODECancerGeneticVariantExample2"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-genetic-variant"
 * status = #final "Final"
 * method = LNC#LA26398-0 "Sequencing"
 // value[x] has alternate codings depending on where to place the interpretation of "Positive or Negative".
@@ -42,8 +38,6 @@ Description: "mCODE Example for Cancer Genetic Variant"
 Instance: mCODECancerGenomicsReportExample1
 InstanceOf: CancerGenomicsReport
 Description: "mCODE Example for Cancer Genomics Report"
-* id = "mCODECancerGenomicsReportExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-genomics-report"
 * status = #final "Final"
 * subject = Reference(mCODEPatientExample1)
 * effectiveDateTime = "2019-04-01"
@@ -55,8 +49,6 @@ Description: "mCODE Example for Cancer Genomics Report"
 Instance: mCODEGenomicRegionStudiedExample1
 InstanceOf: GenomicRegionStudied
 Description: "mCODE Example for Genomic Region Studied"
-* id = "mCODEGenomicRegionStudiedExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-genomic-region-studied"
 * status = #final "final"
 * subject = Reference(mCODEPatientExample1)
 * effectiveDateTime = "2019-04-01"
@@ -66,8 +58,6 @@ Description: "mCODE Example for Genomic Region Studied"
 Instance: mCODETumorMarkerTestExample1
 InstanceOf: TumorMarkerTest
 Description: "mCODE Example for Tumor Marker Test"
-* id = "mCODETumorMarkerTestExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-marker-test"
 * status = #final "final"
 * code = LNC#39004-7 "Epidermal growth factor receptor Ag [Presence] in Tissue"
 * subject = Reference(mCODEPatientExample1)
@@ -78,8 +68,6 @@ Description: "mCODE Example for Tumor Marker Test"
 Instance: mCODEGeneticSpecimenExample1
 InstanceOf: GeneticSpecimen
 Description: "mCODE Example for Genetic Specimen"
-* id = "mCODEGeneticSpecimenExample1"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-genetic-specimen"
 * status = #available "Available"
 * subject = Reference(mCODEPatientExample1)
 * processing.timeDateTime = "2019-03-20"

--- a/input/fsh/EX_Example1_TumorSize.fsh
+++ b/input/fsh/EX_Example1_TumorSize.fsh
@@ -1,7 +1,6 @@
 Instance: example1-mcode-tumor-size
 InstanceOf: TumorSize
 Description: "EXPERIMENTAL example of a resource conforming to the tumor size profile."
-* id = "example1-mcode-tumor-size"
 * status = #final
 * method = LNC#24419-4 "Pathology report gross observation"
 * subject = Reference(Patient/mCODEPatientExample1)
@@ -13,7 +12,6 @@ Description: "EXPERIMENTAL example of a resource conforming to the tumor size pr
 Instance: example1-mcode-tumor
 InstanceOf: Tumor
 Description: "EXPERIMENTAL example of a resource conforming to the tumor profile."
-* id = "example1-mcode-tumor"
 * patient = Reference(Patient/mCODEPatientExample1)
 // Resources conforming to this profile indicate that the tumor is still in the body.
 // This implies it is being measured by radiology. The identifier here is a hypothetical

--- a/input/fsh/EX_Group.fsh
+++ b/input/fsh/EX_Group.fsh
@@ -3,8 +3,6 @@ InstanceOf: Group
 Usage: #example
 Title: "mCODE Patient Group Example"
 Description: "Example of a Group identifying mCODE Patients"
-
-* id = "mCODEPatientGroupExample1"
 * type = #person
 * actual = true
 

--- a/input/fsh/EX_Scenario1.fsh
+++ b/input/fsh/EX_Scenario1.fsh
@@ -3,7 +3,6 @@
 Instance: scenario1-mcode-cancer-patient
 InstanceOf: CancerPatient
 Description: "Extended example 1: example cancer patient"
-* id = "scenario1-mcode-cancer-patient"
 * identifier.use = #usual
 * identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
 * identifier.system = "http://hospital.example.org"
@@ -30,7 +29,6 @@ Description: "Extended example 1: example cancer patient"
 Instance: scenario1-mcode-cancer-disease-status
 InstanceOf: CancerDiseaseStatus
 Description: "Extended example 1: example showing disease status (patient's condition improved)"
-* id = "scenario1-mcode-cancer-disease-status"
 * extension[evidenceType].valueCodeableConcept = SCT#363679005 "Imaging (procedure)"
 * status = #final "final"
 * code = LNC#88040-1 "Response to cancer treatment"
@@ -44,8 +42,6 @@ Description: "Extended example 1: example showing disease status (patient's cond
 Instance: scenario1-mcode-cancer-related-comorbidities
 InstanceOf: CancerRelatedComorbidities
 Description: "mCODE Example for Cancer-Related Comorbidities"
-* id = "scenario1-mcode-cancer-related-comorbidities"
-* meta.profile = "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-comorbidities"
 * subject = Reference(scenario1-mcode-cancer-patient)
 * performer = Reference(scenario1-us-core-practitioner)
 * status = #final "final"
@@ -69,7 +65,6 @@ Description: "mCODE Example for Cancer-Related Comorbidities"
 Instance: scenario1-mcode-comorbid-condition-depression
 InstanceOf: USCoreCondition
 Description: "Extended example 1: example showing comorbid condition (depression)"
-* id = "scenario1-mcode-comorbid-condition-depression"
 * clinicalStatus = ClinStatus#active
 * verificationStatus = VerStatus#confirmed
 * category = CondCat#problem-list-item
@@ -81,7 +76,6 @@ Description: "Extended example 1: example showing comorbid condition (depression
 Instance: scenario1-mcode-comorbid-condition-hypertension
 InstanceOf: USCoreCondition
 Description: "Extended example 1: example showing comorbid condition (hypertension)"
-* id = "scenario1-mcode-comorbid-condition-hypertension"
 * clinicalStatus = ClinStatus#active
 * verificationStatus = VerStatus#confirmed
 * category = CondCat#problem-list-item
@@ -93,7 +87,6 @@ Description: "Extended example 1: example showing comorbid condition (hypertensi
 Instance: scenario1-mcode-ecog-performance-status
 InstanceOf: ECOGPerformanceStatus
 Description: "Extended example 1: example showing ECOG performance status"
-* id = "scenario1-mcode-ecog-performance-status"
 * status = #final "final"
 * subject = Reference(scenario1-mcode-cancer-patient)
 * effectiveDateTime = "2018-03-01"
@@ -105,7 +98,6 @@ Description: "Extended example 1: example showing ECOG performance status"
 Instance: scenario1-mcode-cancer-related-surgical-procedure-mastectomy
 InstanceOf: CancerRelatedSurgicalProcedure
 Description: "Extended example 1: example showing partial mastectomy surgical procedure"
-* id = "scenario1-mcode-cancer-related-surgical-procedure-mastectomy"
 * extension[treatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent (qualifier value)"
 * status = #completed "completed"
 * code = SCT#64368001 "Partial mastectomy (procedure)"
@@ -118,7 +110,6 @@ Description: "Extended example 1: example showing partial mastectomy surgical pr
 Instance: scenario1-mcode-cancer-related-radiation-procedure
 InstanceOf: CancerRelatedRadiationProcedure
 Description: "Extended example 1: example showing radiation treatment"
-* id = "scenario1-mcode-cancer-related-radiation-procedure"
 * extension[treatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent (qualifier value)"
 * status = #completed "completed"
 * code = SCT#385798007 "Radiation therapy care (regime/therapy)"
@@ -131,7 +122,6 @@ Description: "Extended example 1: example showing radiation treatment"
 Instance: scenario1-mcode-primary-cancer-condition
 InstanceOf: PrimaryCancerCondition
 Description: "Extended example 1: example showing primary cancer condition"
-* id = "scenario1-mcode-primary-cancer-condition"
 * extension[histologyMorphologyBehavior].valueCodeableConcept = SCT#413448000 "Adenocarcinoma, no subtype, intermediate grade (morphologic abnormality)"
 * clinicalStatus = ClinStatus#remission
 * verificationStatus = VerStatus#confirmed
@@ -146,7 +136,6 @@ Description: "Extended example 1: example showing primary cancer condition"
 Instance: scenario1-mcode-tnm-clinical-stage-group
 InstanceOf: TNMClinicalStageGroup
 Description: "Extended example 1: example showing TNM staging (stage group)"
-* id = "scenario1-mcode-tnm-clinical-stage-group"
 * status = #final "final"
 * code = LNC#21908-9 "Stage group.clinical Cancer"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -160,7 +149,6 @@ Description: "Extended example 1: example showing TNM staging (stage group)"
 Instance: scenario1-mcode-tnm-primary-tumor-category
 InstanceOf: TNMClinicalPrimaryTumorCategory
 Description: "Extended example 1: example showing TNM staging (T)"
-* id = "scenario1-mcode-tnm-primary-tumor-category"
 * status = #final "final"
 * code = LNC#21905-5 "Primary tumor.clinical [Class] Cancer"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -171,7 +159,6 @@ Description: "Extended example 1: example showing TNM staging (T)"
 Instance: scenario1-mcode-tnm-clinical-regional-nodes-category
 InstanceOf: TNMClinicalRegionalNodesCategory
 Description: "Extended example 1: example showing TNM staging (N)"
-* id = "scenario1-mcode-tnm-clinical-regional-nodes-category"
 * status = #final "final"
 * code = LNC#21906-3 "Regional lymph nodes.clinical [Class] Cancer"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -182,7 +169,6 @@ Description: "Extended example 1: example showing TNM staging (N)"
 Instance: scenario1-mcode-tnm-clinical-distant-metastases-category
 InstanceOf: TNMClinicalDistantMetastasesCategory
 Description: "Extended example 1: example showing TNM staging (M)"
-* id = "scenario1-mcode-tnm-clinical-distant-metastases-category"
 * status = #final "final"
 * code = LNC#21907-1 "Distant metastases.clinical [Class] Cancer"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -193,7 +179,6 @@ Description: "Extended example 1: example showing TNM staging (M)"
 Instance: scenario1-mcode-tumor-marker-test-er
 InstanceOf: TumorMarkerTest
 Description: "Extended example 1: example showing ER status"
-* id = "scenario1-mcode-tumor-marker-test-er"
 * status = #final "final"
 * code = LNC#85337-4 "Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -204,7 +189,6 @@ Description: "Extended example 1: example showing ER status"
 Instance: scenario1-mcode-tumor-marker-test-pr
 InstanceOf: TumorMarkerTest
 Description: "Extended example 1: example showing PR status"
-* id = "scenario1-mcode-tumor-marker-test-pr"
 * status = #final "final"
 * code = LNC#85339-0 "Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -215,7 +199,6 @@ Description: "Extended example 1: example showing PR status"
 Instance: scenario1-mcode-tumor-marker-test-her2
 InstanceOf: TumorMarkerTest
 Description: "Extended example 1: example showing HER2 status"
-* id = "scenario1-mcode-tumor-marker-test-her2"
 * status = #final "final"
 * code = LNC#48676-1 "HER2 [Interpretation] in Tissue"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -226,7 +209,6 @@ Description: "Extended example 1: example showing HER2 status"
 Instance: scenario1-mcode-tumor-marker-test-oncotype-dx
 InstanceOf: TumorMarkerTest
 Description: "Extended example 1: example showing Oncotype DX breast recurrence score. Note that this test has no assigned LOINC code, so GTR is being used as a backup. Only the score from the Oncotype DX panel (as opposed to variant data from the genes in the panel) is represented here."
-* id = "scenario1-mcode-tumor-marker-test-oncotype-dx"
 * status = #final "final"
 * code.coding[0] = OtherSpecifyCS#OtherTumorMarkerTest "Other Tumor Marker Test, Specify"
 * code.coding[1] = GTR#509910 "Oncotype DX Breast Recurrence Score Assay"
@@ -240,7 +222,6 @@ Description: "Extended example 1: example showing Oncotype DX breast recurrence 
 Instance: scenario1-mcode-cancer-genomics-report
 InstanceOf: CancerGenomicsReport
 Description: "Extended example 1: example of gene panel report"
-* id = "scenario1-mcode-cancer-genomics-report"
 * status = #final "final"
 * category[0] = DiagnosticService#LAB
 * category[1] = DiagnosticService#GE
@@ -254,7 +235,6 @@ Description: "Extended example 1: example of gene panel report"
 Instance: scenario1-mcode-genomic-region-studied
 InstanceOf: GenomicRegionStudied
 Description: "Extended example 1: example showing which regions were included in the genomics panel"
-* id = "scenario1-mcode-genomic-region-studied"
 * status = #final "final"
 * code = LNC#53041-0 "DNA region of interest panel"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -272,7 +252,6 @@ Description: "Extended example 1: example showing which regions were included in
 Instance: scenario1-mcode-genetic-specimen
 InstanceOf: GeneticSpecimen
 Description: "Extended example 1: example showing genetic specimen for sequencing"
-* id = "scenario1-mcode-genetic-specimen"
 * status = #available "available"
 * type = http://terminology.hl7.org/CodeSystem/v2-0487#TISS
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -283,7 +262,6 @@ Description: "Extended example 1: example showing genetic specimen for sequencin
 Instance: scenario1-mcode-cancer-genetic-variant
 InstanceOf: CancerGeneticVariant
 Description: "Extended example 1: example showing genetic variant found by breast cancer genomics panel"
-* id = "scenario1-mcode-cancer-genetic-variant"
 * status = #final "final"
 * code = LNC#69548-6 "Genetic variant assessment"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -298,7 +276,6 @@ Description: "Extended example 1: example showing genetic variant found by breas
 Instance: scenario1-mcode-cancer-related-medication-chemo-doxorubicin
 InstanceOf: CancerRelatedMedicationRequest
 Description: "Extended example 1: example showing chemotherapy medication"
-* id = "scenario1-mcode-cancer-related-medication-chemo-doxorubicin"
 * extension[treatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent (qualifier value)"
 * status = #active "active"
 * category = MedReqCat#outpatient
@@ -319,7 +296,6 @@ Description: "Extended example 1: example showing chemotherapy medication"
 Instance: scenario1-mcode-cancer-related-medication-chemo-cyclophosphamide
 InstanceOf: CancerRelatedMedicationRequest
 Description: "Extended example 1: example showing chemotherapy medication"
-* id = "scenario1-mcode-cancer-related-medication-chemo-cyclophosphamide"
 * extension[treatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent (qualifier value)"
 * status = #active "active"
 * category = MedReqCat#outpatient
@@ -341,7 +317,6 @@ Description: "Extended example 1: example showing chemotherapy medication"
 Instance: scenario1-mcode-cancer-related-medication-chemo-paclitaxel
 InstanceOf: CancerRelatedMedicationRequest
 Description: "Extended example 1: example showing chemotherapy medication"
-* id = "scenario1-mcode-cancer-related-medication-chemo-paclitaxel"
 * extension[treatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent (qualifier value)"
 * status = #active "active"
 * category = MedReqCat#outpatient
@@ -362,7 +337,6 @@ Description: "Extended example 1: example showing chemotherapy medication"
 Instance: scenario1-mcode-cancer-related-medication-anastrozole
 InstanceOf: CancerRelatedMedicationRequest
 Description: "Extended example 1: example showing chemotherapy medication"
-* id = "scenario1-mcode-cancer-related-medication-anastrozole"
 * extension[treatmentIntent].valueCodeableConcept = SCT#373808002 "Curative - procedure intent (qualifier value)"
 * status = #active "active"
 * category = MedReqCat#community
@@ -384,7 +358,6 @@ Description: "Extended example 1: example showing chemotherapy medication"
 Instance: scenario1-us-core-practitioner
 InstanceOf: USCorePractitioner
 Description: "Extended example 1: example practitioner"
-* id = "scenario1-us-core-practitioner"
 * identifier[NPI].value = "9988776655"
 * name.family = "Anydoc"
 * name.given[0] = "Kyle"
@@ -403,7 +376,6 @@ Description: "Extended example 1: example practitioner"
 Instance: scenario1-practitioner2-mcode
 InstanceOf: USCorePractitioner
 Description: "Extended example 1: example practitioner (pathologist)"
-* id = "scenario1-practitioner2-mcode"
 * identifier[NPI].value = "1122334455"
 * name.family = "Pathologist"
 * name.given[0] = "Sam"
@@ -421,7 +393,6 @@ Description: "Extended example 1: example practitioner (pathologist)"
 Instance: scenario1-organization1-mcode
 InstanceOf: Organization
 Description: "Extended example 1: example organization"
-* id = "scenario1-organization1-mcode"
 * active = true
 * type = http://terminology.hl7.org/CodeSystem/organization-type#prov "Healthcare Provider"
 * name = "Physician Services, Inc."
@@ -438,7 +409,6 @@ Description: "Extended example 1: example organization"
 Instance: scenario1-us-core-procedure-biopsy
 InstanceOf: USCoreProcedure
 Description: "Extended example 1: example biopsy procedure"
-* id = "scenario1-us-core-procedure-biopsy"
 * status = #completed "completed"
 * code = SCT#723990008 "Biopsy of breast using ultrasonographic guidance (procedure)"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -451,7 +421,6 @@ Description: "Extended example 1: example biopsy procedure"
 Instance: scenario1-us-core-procedure-mammogram
 InstanceOf: USCoreProcedure
 Description: "Extended example 1: example mammogram"
-* id = "scenario1-us-core-procedure-mammogram"
 * status = #completed "completed"
 * code = SCT#71651007 "Mammography (procedure)"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -462,7 +431,6 @@ Description: "Extended example 1: example mammogram"
 Instance: scenario1-us-core-smoking-status
 InstanceOf: USCoreSmokingStatusProfile
 Description: "Extended example 1: example showing smoking status"
-* id = "scenario1-us-core-smoking-status"
 * status = #final "final"
 * code = LNC#72166-2 "Tobacco smoking status"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -472,7 +440,6 @@ Description: "Extended example 1: example showing smoking status"
 Instance: scenario1-observation-smoking-history
 InstanceOf: Observation
 Description: "Extended example 1: example showing smoking history"
-* id = "scenario1-observation-smoking-history"
 * status = #final "final"
 * category = ObsCat#social-history "Social History"
 * code = SCT#401201003 "Cigarette pack-years (observable entity)" // No LOINC available
@@ -483,7 +450,6 @@ Description: "Extended example 1: example showing smoking history"
 Instance: scenario1-us-core-condition-anxiety
 InstanceOf: USCoreCondition
 Description: "Extended example 1: example showing comorbid condition (anxiety)"
-* id = "scenario1-us-core-condition-anxiety"
 * clinicalStatus = ClinStatus#active "Active"
 * verificationStatus = VerStatus#confirmed "Confirmed"
 * category = CondCat#problem-list-item "Problem List Item"
@@ -494,7 +460,6 @@ Description: "Extended example 1: example showing comorbid condition (anxiety)"
 Instance: scenario1-family-member-history-aunt
 InstanceOf: FamilyMemberHistory
 Description: "Extended example 1: example showing family member history of cancer"
-* id = "scenario1-family-member-history-aunt"
 * status = #completed "completed"
 * patient = Reference(scenario1-mcode-cancer-patient)
 * relationship = http://terminology.hl7.org/CodeSystem/v3-RoleCode#MAUNT "maternal aunt"
@@ -506,7 +471,6 @@ Description: "Extended example 1: example showing family member history of cance
 Instance: scenario1-family-member-history-sister
 InstanceOf: FamilyMemberHistory
 Description: "Extended example 1: example showing family member history of cancer"
-* id = "scenario1-family-member-history-sister"
 * status = #completed "completed"
 * patient = Reference(scenario1-mcode-cancer-patient)
 * relationship = http://terminology.hl7.org/CodeSystem/v3-RoleCode#NSIS "natural sister"
@@ -519,7 +483,6 @@ Description: "Extended example 1: example showing family member history of cance
 Instance: scenario1-family-member-history-uncle
 InstanceOf: FamilyMemberHistory
 Description: "Extended example 1: example showing family member history of cancer"
-* id = "scenario1-family-member-history-uncle"
 * status = #completed "completed"
 * patient = Reference(scenario1-mcode-cancer-patient)
 * relationship = http://terminology.hl7.org/CodeSystem/v3-RoleCode#PUNCLE "paternal uncle"
@@ -530,7 +493,6 @@ Description: "Extended example 1: example showing family member history of cance
 Instance: scenario1-specimen-tumor
 InstanceOf: Specimen
 Description: "Extended example 1: example tumor specimen"
-* id = "scenario1-specimen-tumor"
 * status = #available "available"
 * type = http://terminology.hl7.org/CodeSystem/v2-0487#TUMOR "Tumor"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -540,7 +502,6 @@ Description: "Extended example 1: example tumor specimen"
 Instance: scenario1-diagnosticreport-pathology
 InstanceOf: USCoreDiagnosticReportLab
 Description: "Extended example 1: example of pathology findings represented as a DiagnosticReport resource."
-* id = "scenario1-diagnosticreport-pathology"
 * status = #final "final"
 * category[0] = DiagnosticService#LAB
 * category[1] = DiagnosticService#SP "Surgical Pathology"
@@ -560,7 +521,6 @@ Description: "Extended example 1: example of pathology findings represented as a
 Instance: scenario1-observation-tumor-invasion-negative
 InstanceOf: USCoreObservationLab
 Description: "Extended example 1: example showing negative invasion for the removed tumor"
-* id = "scenario1-observation-tumor-invasion-negative"
 * status = #final "final"
 * code = SCT#370052007 "Status of invasion by tumor (observable entity)" // No LOINC for invasion status
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -571,7 +531,6 @@ Description: "Extended example 1: example showing negative invasion for the remo
 Instance: scenario1-observation-tumor-negative-margins
 InstanceOf:  USCoreObservationLab
 Description: "Extended example 1: example showing negative margins for the removed tumor"
-* id = "scenario1-observation-tumor-negative-margins"
 * status = #final "final"
 * code = LNC#44669-0 "Margin involvement in Breast tumor"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -582,7 +541,6 @@ Description: "Extended example 1: example showing negative margins for the remov
 Instance: scenario1-observation-tumor-sentinel-nodes
 InstanceOf:  USCoreObservationLab
 Description: "Extended example 1: example showing 3 sentinel lymph nodes were examined"
-* id = "scenario1-observation-tumor-sentinel-nodes"
 * status = #final "final"
 * code = LNC#92832-5 "Sentinel lymph nodes with metastasis [#] in Cancer specimen"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -594,7 +552,6 @@ Description: "Extended example 1: example showing 3 sentinel lymph nodes were ex
 Instance: scenario1-observation-tumor-size
 InstanceOf:  USCoreObservationLab
 Description: "Extended example 1: example showing tumor size"
-* id = "scenario1-observation-tumor-size"
 * status = #final "final"
 * code = LNC#21889-1 "Size Tumor"
 * subject = Reference(scenario1-mcode-cancer-patient)
@@ -607,7 +564,6 @@ Description: "Extended example 1: example showing tumor size"
 Instance: scenario1-observation-tumor-dcis
 InstanceOf:  USCoreObservationLab
 Description: "Extended example 1: example showing DCIS diagnosis"
-* id = "scenario1-observation-tumor-dcis"
 * status = #final "final"
 * code = LNC#29308-4 "Diagnosis"
 * subject = Reference(scenario1-mcode-cancer-patient)

--- a/input/fsh/EX_Scenario1_Bundle.fsh
+++ b/input/fsh/EX_Scenario1_Bundle.fsh
@@ -1,8 +1,6 @@
 Instance: scenario1-mcode-patient-bundle
 InstanceOf: MCODEPatientBundle
 Description: "Extended example 1 as a mCODE Patient Bundle"
-* id = "scenario1-mcode-patient-bundle"
-
 // Named slices, required
 * entry[cancerPatient].resource = scenario1-mcode-cancer-patient
 * entry[cancerPatient].fullUrl = "http://example.org/fhir/Patient/scenario1-mcode-cancer-patient"


### PR DESCRIPTION
Don't need meta.profile or id, since these are automatically generated by SUSHI