### PR TITLE
Updates from TRG and RO groups meeting today

### DIFF
--- a/FHIR-us-mcode.xml
+++ b/FHIR-us-mcode.xml
@@ -24,7 +24,6 @@
 <artifact deprecated="true" id="ValueSet/mcode-cancer-related-surgical-procedure-value-set" key="cancer-related-surgical-procedure-value-set" name="Cancer Related Surgical Procedure Value Set"/>
 <artifact deprecated="true" id="Profile/mcode-cancer-stage-parent" key="cancer-stage-parent" name="Cancer Stage Parent"/>
 <artifact id="ValueSet/mcode-cancer-staging-system-vs" key="cancer-staging-system-value-set" name="Cancer Staging System Value Set"/>
-<artifact id="StructureDefinition/mcode-cancer-related-comorbidities-elixhauser" key="StructureDefinition-mcode-cancer-related-comorbidities-elixhauser" name="Cancer-Related Elixhauser Comorbidities"/>
 <artifact id="StructureDefinition/mcode-cancer-related-medication-administration" key="StructureDefinition-mcode-cancer-related-medication-administration" name="Cancer-Related Medication Administration"/>
 <artifact id="StructureDefinition/mcode-cancer-related-medication-request" key="StructureDefinition-mcode-cancer-related-medication-request" name="Cancer-Related Medication Request"/>
 <artifact id="StructureDefinition/mcode-cancer-related-surgical-procedure" key="StructureDefinition-mcode-cancer-related-surgical-procedure" name="Cancer-Related Surgical Procedure"/>
@@ -219,7 +218,6 @@
 <artifact deprecated="true" id="Example/mcode-tnm-pathological-regional-nodes-category-example-01" key="mcode-tnm-pathological-regional-nodes-category-example-01" name="mCODETNMPathologicalRegionalNodesCategoryExample01"/>
 <artifact deprecated="true" id="Example/mcode-tnm-pathological-stage-group-example-01" key="mcode-tnm-pathological-stage-group-example-01" name="mCODETNMPathologicalStageGroupExample01"/>
 <artifact deprecated="true" id="Example/mcode-tumor-marker-example-01" key="mcode-tumor-marker-example-01" name="mCODETumorMarkerExample01"/>
-<artifact id="Observation/mcode-comorbidities-elixhauser-john-anyperson" key="Observation-mcode-comorbidities-elixhauser-john-anyperson" name="mcode-comorbidities-elixhauser-john-anyperson"/>
 <artifact id="Bundle/mcode-patient-bundle-jenny-m" key="Bundle-mcode-patient-bundle-jenny-m" name="mcode-patient-bundle-jenny-m"/>
 <artifact id="OperationDefinition/mcode-patient-everything" key="OperationDefinition-mcode-patient-everything" name="mcode-patient-everything"/>
 <artifact id="CapabilityStatement/mcode-receiver-cancer-conditions-then-patients" key="CapabilityStatement-mcode-receiver-cancer-conditions-then-patients" name="mcode-receiver-cancer-conditions-then-patients"/>

--- a/input/fsh/EX_Basic.fsh
+++ b/input/fsh/EX_Basic.fsh
@@ -38,7 +38,7 @@ Description: "mCODE Example for Cancer Disease Status"
 * valueCodeableConcept = SCT#268910001 "Patient's condition improved (finding)"
 
 Instance: cancer-related-mcode-comorbidities-elixhauser-john-anyperson
-InstanceOf: CancerRelatedComorbiditiesElixhauser
+InstanceOf: ComorbiditiesElixhauser
 Description: "mCODE Example for Cancer-Related Comorbidities"
 * subject = Reference(cancer-patient-john-anyperson)
 * performer = Reference(us-core-practitioner-kyle-anydoc)
@@ -52,26 +52,6 @@ Description: "mCODE Example for Cancer-Related Comorbidities"
 * component[chronicPulmonaryDisease].valueCodeableConcept = SCT#2667000 "Absent (qualifier value)"
 * component[obesity].valueCodeableConcept = SCT#2667000 "Absent (qualifier value)"
 * component[peripheralVascularDisease].valueCodeableConcept = SCT#2667000 "Absent (qualifier value)"
-
-
-Instance: mcode-comorbidities-elixhauser-john-anyperson
-InstanceOf: ComorbiditiesElixhauser
-Description: "Example of Elixhauser Comorbidity List without index disease."
-* subject = Reference(cancer-patient-john-anyperson)
-* performer = Reference(us-core-practitioner-kyle-anydoc)
-* status = #final "final"
-// present
-* component[congestiveHeartFailure].valueCodeableConcept = SCT#52101004 "Present (qualifier value)"
-* component[congestiveHeartFailure].extension[conditionCode].valueCodeableConcept = ICD10CM#I50.32 "Chronic diastolic (congestive) heart failure"
-* component[cancerLeukemia].valueCodeableConcept = SCT#52101004 "Present (qualifier value)"
-* component[cancerLeukemia].extension[conditionCode].valueCodeableConcept = ICD10CM#C91.01  "Acute lymphoblastic leukemia, in remission"
-// absent or unknown
-* component[arthropathy].valueCodeableConcept = SCT#2667000 "Absent (qualifier value)"
-* component[chronicPulmonaryDisease].valueCodeableConcept = SCT#2667000 "Absent (qualifier value)"
-* component[obesity].valueCodeableConcept = SCT#2667000 "Absent (qualifier value)"
-* component[peripheralVascularDisease].valueCodeableConcept = SCT#2667000 "Absent (qualifier value)"
-* component[drugAbuse].valueCodeableConcept = SCT#261665006 "Unknown (qualifier value)"
-* component[hypothyroidism].valueCodeableConcept = SCT#261665006 "Unknown (qualifier value)"
 
 Instance: cancer-patient-john-anyperson
 InstanceOf: CancerPatient

--- a/input/fsh/EX_ExtendedExample.fsh
+++ b/input/fsh/EX_ExtendedExample.fsh
@@ -115,7 +115,7 @@ Description: "Extended example: example showing family member history of cancer"
 * deceasedBoolean = true
 
 Instance: cancer-related-mcode-comorbidities-elixhauser-jenny-m
-InstanceOf: CancerRelatedComorbiditiesElixhauser
+InstanceOf: ComorbiditiesElixhauser
 Description: "mCODE Example for Cancer-Related Comorbidities"
 * subject = Reference(cancer-patient-jenny-m)
 * performer = Reference(us-core-practitioner-owen-oncologist)
@@ -551,7 +551,6 @@ Description: "Extended example: example showing radiation treatment"
 * extension[technique].valueCodeableConcept = RO#3D "Three Dimensional"
 * extension[doseDelivered].extension[targetVolume].valueString = "Left breast PTV-1"
 * extension[doseDelivered].extension[dosePerFraction].valueQuantity = 200 'cGy'
-* extension[doseDelivered].extension[prescribedFractions].valuePositiveInt = 25
 * extension[doseDelivered].extension[deliveredFractions].valueUnsignedInt = 25
 * extension[doseDelivered].extension[totalDoseDelivered].valueQuantity = 5000 'cGy' "Centigray"
 * subject = Reference(cancer-patient-jenny-m)

--- a/input/fsh/SD_Bundle.fsh
+++ b/input/fsh/SD_Bundle.fsh
@@ -27,7 +27,7 @@ Description: "A collection of data for an mCODE cancer patient."
     cancerGenomicsReport 0..* MS and
     geneticSpecimen 0..* MS and
     genomicRegionStudied 0..* MS and
-    cancerRelatedComorbiditiesElixhauser 0..* MS and
+    comorbiditiesElixhauser 0..* MS and
     vitalSign 0..* MS and
     tumor 0..* MS and
     tumorSize 0..* MS
@@ -52,7 +52,7 @@ Description: "A collection of data for an mCODE cancer patient."
 * entry[cancerGenomicsReport] ^short = "Cancer Genomics Report(s)"
 * entry[geneticSpecimen] ^short = "Genetic Specimen(s)"
 * entry[genomicRegionStudied] ^short = "Genomic Region(s) Studied"
-* entry[cancerRelatedComorbiditiesElixhauser] ^short = "Cancer-Related Comorbidities"
+* entry[comorbiditiesElixhauser] ^short = "Cancer-Related Comorbidities"
 * entry[vitalSign] ^short = "Patient Height(s), Weight(s), Blood Pressure(s), or other vital signs"
 * entry[tumor] ^short = "Identified Tumors"
 * entry[tumorSize] ^short = "Tumor Size Measurements"
@@ -78,7 +78,7 @@ Description: "A collection of data for an mCODE cancer patient."
 * entry[cancerGenomicsReport] ^definition = "DiagnosticReport resource(s) representing Cancer Genomics Reports"
 * entry[geneticSpecimen] ^definition = "Specimen resource(s) representing Genetic Specimens."
 * entry[genomicRegionStudied] ^definition = "Observation resource(s) representing Genomic Regions Studied."
-* entry[cancerRelatedComorbiditiesElixhauser] ^definition = "Observation resource(s) representing Cancer-Related Comorbidities."
+* entry[comorbiditiesElixhauser] ^definition = "Observation resource representing the patient's comorbidities."
 * entry[vitalSign] ^definition = "Observation resource(s) representing patient height, weight, blood pressure, and other vital signs."
 * entry[tumor] ^definition = "Any tumor(s) being tracked over time."
 * entry[tumorSize] ^definition = "Tumor size measurement(s)."
@@ -105,7 +105,7 @@ Description: "A collection of data for an mCODE cancer patient."
 * entry[cancerGenomicsReport].resource only CancerGenomicsReport
 * entry[geneticSpecimen].resource only GeneticSpecimen
 * entry[genomicRegionStudied].resource only GenomicRegionStudied
-* entry[cancerRelatedComorbiditiesElixhauser].resource only CancerRelatedComorbiditiesElixhauser
+* entry[comorbiditiesElixhauser].resource only ComorbiditiesElixhauser
 * entry[vitalSign].resource only http://hl7.org/fhir/StructureDefinition/vitalsigns
 * entry[tumor].resource only Tumor
 * entry[tumorSize].resource only TumorSize

--- a/input/fsh/SD_ComorbidCondition.fsh
+++ b/input/fsh/SD_ComorbidCondition.fsh
@@ -31,12 +31,13 @@ Title: "Elixhauser Comorbidities"
 Description: "Comorbid condition checklist and optional risk score, using Elixhauser comorbidity categories as defined by the Agency for Healthcare Research and Quality (AHRQ) Healthcare Cost and Utilization Project (H-CUP)."
 * ^abstract = false
 * code = COMORB#COMORBID_OBS
+* focus only Reference(PrimaryCancerCondition)
+* focus ^definition = "A reference to the cancer condition that is the context for the current list of comorbid conditions."
 * component.value[x] from PresentAbsentUnknownVS (required)
 * component ^slicing.discriminator.type = #pattern
 * component ^slicing.discriminator.path = "code"
 * component ^slicing.rules = #closed
 * component ^slicing.description = "Slice based on the component.code pattern"
-// slices
 * component contains 
     aids 0..1 and
     alcoholAbuse 0..1 and
@@ -153,8 +154,6 @@ Description: "Comorbid condition checklist and optional risk score, using Elixha
 * component[valvularDisease] ^short = "Valvular Disease"
 * component[weightLoss].code = COMORB#WGHTLOSS
 * component[weightLoss] ^short = "Weight Loss"
-
-
 // value[x] constraints
 * component[aids].extension[conditionCode].value[x] from ElixhauserAidsVS
 * component[alcoholAbuse].extension[conditionCode].value[x] from ElixhauserAlcoholAbuseVS
@@ -194,28 +193,18 @@ Description: "Comorbid condition checklist and optional risk score, using Elixha
 * component[ulcer].extension[conditionCode].value[x] from ElixhauserUlcerVS
 * component[valvularDisease].extension[conditionCode].value[x] from ElixhauserValvularDiseaseVS
 * component[weightLoss].extension[conditionCode].value[x] from ElixhauserWeightLossVS
-// MS flags omitted since this profile is not associated with mCODE use cases
-
-Profile: CancerRelatedComorbiditiesElixhauser
-Parent: ComorbiditiesElixhauser
-Id: mcode-cancer-related-comorbidities-elixhauser
-Title: "Cancer-Related Elixhauser Comorbidities"
-Description: "Comorbid conditions using the Elixhauser comorbidity categories, defined by the Agency for Healthcare Research and Quality (AHRQ) Healthcare Cost and Utilization Project (H-CUP), from the perspective of the primary cancer condition."
-* focus only Reference(PrimaryCancerCondition)
-* focus ^definition = "A reference to the cancer condition that is the context for the current list of comorbid conditions."
-* insert NotUsed(value[x])
-* insert NotUsed(component[cancerLeukemia])
-* insert NotUsed(component[cancerLymphoma])
-* insert NotUsed(component[cancerMetastatic])
-* insert NotUsed(component[cancerSolidInSitu])
-* insert NotUsed(component[cancerSolidMalignant])
-// Must Supports -- none are inherited
+// Must Supports -- none inherited
 * component and status and code and subject and focus and effective[x] MS
 * insert ComorbidityMustSupports(aids)
 * insert ComorbidityMustSupports(alcoholAbuse)
 * insert ComorbidityMustSupports(deficiencyAnemia)
 * insert ComorbidityMustSupports(arthropathy)
 * insert ComorbidityMustSupports(bloodLossAnemia)
+* insert ComorbidityMustSupports(cancerLeukemia)
+* insert ComorbidityMustSupports(cancerLymphoma)
+* insert ComorbidityMustSupports(cancerMetastatic)
+* insert ComorbidityMustSupports(cancerSolidInSitu)
+* insert ComorbidityMustSupports(cancerSolidMalignant)
 * insert ComorbidityMustSupports(cerebrovascular)
 * insert ComorbidityMustSupports(congestiveHeartFailure)
 * insert ComorbidityMustSupports(coagulopathy)
@@ -245,7 +234,6 @@ Description: "Comorbid conditions using the Elixhauser comorbidity categories, d
 * insert ComorbidityMustSupports(valvularDisease)
 * insert ComorbidityMustSupports(weightLoss)
 
-// SCT#762713009 "Charlson Comorbidity Index (assessment scale)"
 
 RuleSet: ComorbidityMustSupports(sliceName)
 * component[{sliceName}] MS

--- a/input/fsh/SD_Radiotherapy.fsh
+++ b/input/fsh/SD_Radiotherapy.fsh
@@ -92,18 +92,16 @@ Description: "Extension capturing a technique of external beam or brachytherapy 
 Extension: RadiotherapyDose
 Id: mcode-radiotherapy-dose
 Title: "Radiotherapy Dose"
-Description: "Dose parameters for one target volume, including dose per fraction, number of fractions prescribed and delivered, and total dose delivered."
+Description: "Dose parameters for one target volume, including dose per fraction, number of fractions delivered, and total dose delivered."
 * insert ExtensionContext(Procedure)
 * extension contains
     targetVolume 0..1 and 
     dosePerFraction 0..1 and
-    prescribedFractions 0..1 and
     deliveredFractions 0..1 and
     totalDoseDelivered 0..1
 * extension[targetVolume].value[x] only string
 * extension[dosePerFraction].value[x] only Quantity
 * extension[dosePerFraction].valueQuantity = UCUM#cGy
-* extension[prescribedFractions].value[x] only positiveInt
 * extension[deliveredFractions].value[x] only unsignedInt
 * extension[totalDoseDelivered].value[x] only Quantity
 * extension[totalDoseDelivered].valueQuantity = UCUM#cGy
@@ -112,8 +110,8 @@ Description: "Dose parameters for one target volume, including dose per fraction
 * extension[targetVolume] ^definition = "Text description of the body structure targeted, for example, Chest Wall Lymph Nodes PTV-2. The planning target volume (PTV) identifier MAY be included as a reference to the treatment plan."
 * extension[dosePerFraction] ^short = "Radiation Dose Per Fraction"
 * extension[dosePerFraction] ^definition = "The amount of radiation administered during a single fraction (dose division) of radiation therapy."
-* extension[prescribedFractions] ^short = "Radiation Fractions Prescribed"
-* extension[prescribedFractions] ^definition = "The total number of fractions (treatment divisions) planned for this target volume."
+//* extension[prescribedFractions] ^short = "Radiation Fractions Prescribed"
+//* extension[prescribedFractions] ^definition = "The total number of fractions (treatment divisions) planned for this target volume."
 * extension[deliveredFractions] ^short = "Radiation Fractions Delivered"
 * extension[deliveredFractions] ^definition = "The total number of fractions (treatment divisions) actually delivered for this target volume."
 * extension[totalDoseDelivered] ^short = "Total Radiation Dose Delivered"

--- a/input/fsh/VS_Other.fsh
+++ b/input/fsh/VS_Other.fsh
@@ -64,7 +64,7 @@ Description: "Qualifiers to refine the anatomical location. These include qualif
 ValueSet:   TreatmentTerminationReasonVS
 Id: mcode-treatment-termination-reason-vs
 Title: "Treatment Termination Reason Value Set"
-Description:  "Values used to describe the reasons for stopping a treatment. Includes code for 'treatment completed' as well as codes for unplanned (early) stoppage. Applies to medications and other treatments that take place over a period of time, such as radiation treatments."
+Description:  "Values used to describe the reasons for stopping a treatment or episode of care. Includes code for 'treatment completed' as well as codes for unplanned (early) stoppage. Applies to medications and other treatments that take place over a period of time, such as radiation treatments."
 * ^copyright = "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement"
 * SCT#182992009   "Treatment completed (situation)"
 * SCT#266721009   "No response to treatment (situation)" // more general than SCT#58848006 "Lack of drug action (finding)"  
@@ -72,7 +72,9 @@ Description:  "Values used to describe the reasons for stopping a treatment. Inc
 * SCT#160932005   "Financial problem (finding)" // more general than 454061000124102 "Unable to afford medication (finding)"
 * SCT#105480006   "Refusal of treatment by patient (situation)"  // patient choice or decision
 * SCT#184081006   "Patient has moved away (finding)" // better than SCT#107724000 "Patient transfer (procedure)"
-* SCT#309846006   "Treatment not available (situation)"
+* SCT#309846006   "Treatment not available (situation)" 
+* SCT#399307001   "Lost to follow-up (finding)" // added by mCODE Exec Council recommendation 2/12/2021
+
 
 ValueSet:		TreatmentIntentVS
 Id: mcode-treatment-intent-vs

--- a/input/fsh/VS_Radiotherapy.fsh
+++ b/input/fsh/VS_Radiotherapy.fsh
@@ -40,7 +40,6 @@ Description: "Codes describing the techniques of teleradiotherapy (external beam
 * RO#3D
 * RO#2D
 * RO#IORT
-* RO#COMP
 * RO#PPS
 * RO#PSS
 * RO#MIX
@@ -60,7 +59,6 @@ Description: "Codes describing the techniques of brachytherapy (internal or surf
 * RO#LUM
 * RO#IORT
 * RO#SURF
-* RO#SURF-TEMP
 * RO#ORAL
 
 ValueSet: RadiotherapyTechniqueVS
@@ -80,27 +78,26 @@ Title: "Radiotherapy Code System"
 Description: "Codes describing the modalities, techniques, and devices used in external beam radiotherapy and brachytherapy procedures."
 //-- Codes for Observations -- should ask for a LOINC code
 * #SUMMARY "Radiotherapy Summary" "Identifying code for an observation that summarizes an entire radiotherapy treatment. A course of treatment may contain multiple teleradiotherapy and/or brachytherapy prescriptions, embracing multiple modalities and techniques, and multiple body sites."
-* #EBRT "Teleradiotherapy Prescription Delivery" "Identifying code for an observation that describes delivery of a teleradiotherapy prescription. The scope is a prescription consisting of one or more identical fractions. A new prescription delivery begins when there is a change in the target volume of a body site, treatment fraction size, modality, or treatment technique."
+* #EBRT "Teleradiotherapy Prescription Delivery" "Identifying code for an observation that describes delivery of a teleradiotherapy (external beam) prescription. The scope is a prescription consisting of one or more identical fractions. A new prescription delivery begins when there is a change in the target volume of a body site, treatment fraction size, modality, or treatment technique."
 * #BRACHY "Brachytherapy Prescription Delivery" "Identifying code for an observation that describes delivery of brachytherapy prescription. The scope is one prescription consisting of one or more identical fractions. A new prescription delivery begins when there is a change in the target volume of a body site, treatment fraction size, modality, or treatment technique."
 //-- Teleradiotherapy Modalities
 * #PROTON "Proton Beam Radiation Therapy" "A type of external beam radiation therapy using a beam of proton particles." 
 * #ELECTRON "Electron Beam Radiation Therapy"  "Radiation therapy using electron (beta particle) beam."
 * #NEUTRON "Neutron Beam Radiation Therapy" "A type of radiation therapy that uses a beam of accelerated neutrons."
-* #CARBON  "Carbon Ion Beam Radiation Therapy"  "Ion beam radiation therapy that uses charged carbon particle. Compared to proton beam therapy, the larger mass of carbon results in decreased beam scattering, yielding a sharper dose distribution border with minimal penumbra and two to three times the relative biological effect. [NCI]"
+* #CARBON  "Carbon Ion Beam Radiation Therapy"  "Ion beam radiation therapy that uses charged carbon particle. Compared to proton beam therapy, the larger mass of carbon results in decreased beam scattering, yielding a sharper dose distribution border with minimal penumbra and two to three times the relative biological effect."
 * #PHOTON "Photon Beam Radiation Therapy" "Radiation therapy that uses photons (electromagnetic radiation) to treat tumors, including gamma rays and x-rays."
 //-- Brachytherapy Modalities
-* #LDR "Low-Dose Rate Brachytherapy" "Internal or surface radiation treatment that targets a cancerous tissue with low doses of radiation through the use of inserted temporary or permanent implants. [NCI]"
-* #PDR "Pulsed-Dose Rate Brachytherapy" "Internal or surface radiation using a stronger radiation source than low-dose rate brachytherapy and producing series of short exposures of 10 to 30 minutes in every hour."
-* #HDR  "High dose brachytherapy" "Internal or surface radiation treatment that targets a cancerous tissue with accurate, high doses of radiation through the use of inserted temporary implants."
-* #ELEC "High dose rate electronic brachytherapy" "A modality of internal or surface radiation that uses miniaturized X-ray sources instead of radionuclides to deliver high doses of radiation."
-* #PHARM "Radiopharmaceutical therapy" "The use of radioactive drugs that can be given by mouth or injected."
+* #LDR "Low Dose Rate Brachytherapy" "Internal or surface radiation treatment that targets a cancerous tissue with low dose rates of radiation."
+* #PDR "Pulsed Dose Rate Brachytherapy" "Internal or surface radiation using a stronger radiation source than low dose rate brachytherapy and producing series of short exposures of 10 to 30 minutes in every hour."
+* #HDR  "High Dose Rate Brachytherapy" "Internal or surface radiation treatment that targets a cancerous tissue with high rates of radiation."
+* #ELEC "High Dose Rate Electronic Brachytherapy"  "A modality of internal or surface radiation that uses miniaturized X-ray sources instead of radionuclides to deliver high rates of radiation."
+* #PHARM "Radiopharmaceutical Therapy" "The use of radioactive drugs that can be given by mouth, infused, or injected."
 //-- Teleradiotherapy Techniques
 * #IMRT "Intensity Modulated Radiation Therapy" "A technique of high-precision radiotherapy that uses computer control to deliver precise radiation doses that conform to a three-dimensional (3-D) shape by modulating the intensity of the radiation beam in multiple small volumes."
 * #VMAT "Volumetric Modulated Arc Therapy" "A type of IMRT technique where the radiotherapy machine rotates around the patient, radiating the target in a complete three-dimensional manner with precision and speed."
 * #3D "Three Dimensional"  "Dose calculated with projection onto 3D imaging (e.g. CT or MR) delivered with either static aperture (Collimator, SRS Cone, Static MLC, blocks, etc) or non-IMRT/VMAT dynamic apertures (e.g. field-in-field, dynamic arc) using either single gantry angles or arcs."
 * #2D "Two Dimensional" "Dose calculated without projection onto 3D imaging and delivered without 3D techniques."
 * #IORT "Intraoperative Radiation Therapy" "An intensive radiation treatment administered during surgery."
-* #COMP "Compensator" "In external beam electron therapy, a technique that uses a thickness-varied device to modulate energy and intensity."
 * #PPS  "Particle Passive Scattering" "In proton or carbon ion beam therapy, a technique where the beam is spread out to larger dimension using a scattering device such as lead foil."
 * #PSS "Particle Spot Scanning"  "In proton or carbon ion beam therapy, a technique where accelerated particles are focused into a small beam and then moved (scanned) over target regions in the patient."
 * #MIX "Mixed" "Both Photon and Particle based beams are used to deliver the therapeutic dose"
@@ -112,12 +109,10 @@ Description: "Codes describing the modalities, techniques, and devices used in e
 * #INSTIT "Interstitial"  "Placement or implanting radioactive source into tissue."
 * #INSTIT-PERM "Interstitial-Permanent" "Implantment of a radioactive source into body tissue, and left in place permanently."
 * #INSTIT-TEMP "Interstitial-Temporary"  "Implantment of a radioactive source into body tissue, and removed after a period of time."
-* #VASC "Intravascular" "Placement of a radioactive source into a blood vessel or blood vascular system."
-* #LUM "Intraluminal"  "Placement of a radioactive source into a lumen, usually understood to mean the gastrointestinal tract; less commonly, within the gallbladder or urinary bladder."
-* #SURF "Surface" "Placement of a radioactive source on the skin."
-* #SURF-TEMP "Surface-Temporary" "Placement of a radioactive source on the skin, to be removed after a period of time." 
-* #ORAL "Oral"  "Placement of a radioactive source into the oral cavity." 
-
+* #LUM "Intraluminal"  "Placement of a radioactive source into a lumen, usually understood to mean the gastrointestinal, esophageal, endobrochial, or less commonly, within the bile duct or urinary bladder."
+* #SURF "Surface" "Placement of a radioactive source on the skin." 
+* #VASC "Intravascular" "Placement of a radioactive source into a blood vessel or blood vascular system or vascular injection of radiopharaceutical."
+* #ORAL "Oral"  "Ingestion of radiopharaceutical via oral route."
 
 //----------BODY SITE------------
 

--- a/input/includes/markdown-link-references.md
+++ b/input/includes/markdown-link-references.md
@@ -11,7 +11,6 @@
 [CancerGeneticVariant]: StructureDefinition-mcode-cancer-genetic-variant.html
 [CancerGenomicsReport]: StructureDefinition-mcode-cancer-genomics-report.html
 [CancerPatient]: StructureDefinition-mcode-cancer-patient.html
-[CancerRelatedComorbiditiesElixhauser]: StructureDefinition-mcode-cancer-related-comorbidities-elixhauser.html
 [CancerRelatedMedicationAdministration]: StructureDefinition-mcode-cancer-related-medication-administration.html
 [CancerRelatedMedicationRequest]: StructureDefinition-mcode-cancer-related-medication-request.html
 [CancerRelatedSurgicalProcedure]: StructureDefinition-mcode-cancer-related-surgical-procedure.html

--- a/input/pagecontent/StructureDefinition-mcode-brachytherapy-prescription-delivery-intro.md
+++ b/input/pagecontent/StructureDefinition-mcode-brachytherapy-prescription-delivery-intro.md
@@ -7,7 +7,7 @@ The following table shows valid combinations of modality and technique for brach
 
 | **Brachytherapy Modality**  | **Technique (Delivery Method)**|
 | ----------------------------- | ------------------------------ |
-| Low Dose Rate | Intracavitary, Interstitial-Permanent, Interstitial-Temporary, Surface-Temporary |
+| Low Dose Rate | Intracavitary, Interstitial-Permanent, Interstitial-Temporary, Surface |
 | Pulse Dose Rate | Intracavitary, Interstitial, Intravascular, Intraluminal, IORT|
 | High Dose Rate  | Intracavitary, Intracavitary-IMB, Interstitial, Intravascular, Intraluminal, IORT, Surface |
 | Electronic  | Intracavitary, Intracavitary-IMB, Interstitial, Intraluminal, Surface, IORT |

--- a/input/pagecontent/StructureDefinition-mcode-cancer-related-comorbidities-elixhauser-intro.md
+++ b/input/pagecontent/StructureDefinition-mcode-cancer-related-comorbidities-elixhauser-intro.md
@@ -1,7 +1,0 @@
-### Usage
-
-This profile assumes the current focus or "index" condition is the patient's cancer, and from that perspective, comorbidities are conditions *in addition* to cancer. Therefore, the components related to cancer should not be included in the set of reported comorbidity categories. To report the full set of Elixhauser categories, for example to enable calculation of the Elixhauser comorbidity index, use the [ComorbiditiesElixhauser](StructureDefinition-mcode-comorbidities-elixhauser.html) profile. Since the index cannot be calculated with an incomplete set of comorbid conditions, the place for the index (Observation.value[x]) has also been suppressed in this profile.
-
-### Conformance
-
-Observation resources associated with an mCODE patient with Observation.code LOINC 88040-1 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form.

--- a/input/pagecontent/StructureDefinition-mcode-comorbidities-elixhauser-intro.md
+++ b/input/pagecontent/StructureDefinition-mcode-comorbidities-elixhauser-intro.md
@@ -24,6 +24,11 @@ For any component, "present" or "absent" refers back to a comorbidity category d
 
 If an overall score is calculated, it should be recorded in `Observation.value[x]`. This is not required.
 
+### Usage
+
+This profile assumes the current focus or "index" condition is the patient's cancer. Typically, a cancer condition would not be considered a comorbidity in a cancer patient, but it is possible that there could be pre-existing or concurrent cancer condition could be included in the list of comorbidities. There are many comorbidity categories, and usually only the comorbidities that are present are worth recording. However, if there is a need to know a comorbidity is **not** present, it can be documented using the current structure. Reporting of the actual condition, by reference or by code, is not required.
+
 ### Conformance
 
-This profile is not meant to be used in mCODE. It is the parent profile for the CancerRelatedComorbiditiesElixhauser profile. Because it may be useful for other applications, it is not marked 'abstract'.
+Observation resources associated with an mCODE patient with Observation.code LOINC 88040-1 MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form.
+

--- a/input/pagecontent/StructureDefinition-mcode-patient-bundle-intro.md
+++ b/input/pagecontent/StructureDefinition-mcode-patient-bundle-intro.md
@@ -14,7 +14,7 @@ The bundle MUST also contain following mCODE-conformant resources, if available 
 * Observation resources representing [CancerGeneticVariant](StructureDefinition-mcode-cancer-genetic-variant.html) and [GenomicRegionStudied](StructureDefinition-mcode-genomic-region-studied.html)
 * DiagnosticReport resources representing [CancerGenomicsReport](StructureDefinition-mcode-cancer-genomics-report.html)
 * Specimen resources representing to [GeneticSpecimen](StructureDefinition-mcode-genetic-specimen.html)
-* Observation resource representing to [CancerRelatedComorbiditiesElixhauser](StructureDefinition-mcode-cancer-related-comorbidities-elixhauser.html), and accompanying Condition resources
+* Observation resource representing to [ComorbiditiesElixhauser](StructureDefinition-mcode-comorbidities-elixhauser.html), and accompanying Condition resources
 * Observation resources for patient height, weight, blood pressure
 * Laboratory results from Comprehensive Metabolic Panels (CMP) and Complete Blood Counts (CBC)
 

--- a/input/pagecontent/StructureDefinition-mcode-teleradiotherapy-prescription-delivery-intro.md
+++ b/input/pagecontent/StructureDefinition-mcode-teleradiotherapy-prescription-delivery-intro.md
@@ -3,7 +3,7 @@
 
 The following table shows valid combinations of modality and technique for external beam radiotherapy. They are not enforced in the profile. Other combinations and additional techniques may be possible. The modality is represented by `mcode-radiotherapy-modality` extension, technique using the `mcode-radiotherapy-technique` extension.
 
-| **External Beam Modality ** | **Technique** |
+| **External Beam Modality** | **Technique** |
 | ------------------- | ------------------ |
 | Photons  | IMRT, VMAT, 3D, 2D, IORT |
 | Electrons| 3D, 2D, IORT, COMP |

--- a/input/pagecontent/ValueSet-mcode-brachytherapy-technique-vs-intro.md
+++ b/input/pagecontent/ValueSet-mcode-brachytherapy-technique-vs-intro.md
@@ -21,7 +21,6 @@ The following table shows mappings from SNOMED CT and NCI Thesaurus to of brachy
 | VASC | none | none |
 | LUM | 384691004 Intraluminal brachytherapy (procedure) | none |
 | SURF | 14473006 Surface brachytherapy (procedure) | none |
-| SURF-TEMP | none | none |
-| ORAL | 69568002 Oral radiation (procedure) _or_ 16560241000119104 Oral radionuclide therapy (procedure) | none |
+| ORAL | 16560241000119104 Oral radionuclide therapy (procedure) | none |
 {: .grid }
 

--- a/input/pagecontent/ValueSet-mcode-teleradiotherapy-technique-vs-intro.md
+++ b/input/pagecontent/ValueSet-mcode-teleradiotherapy-technique-vs-intro.md
@@ -18,7 +18,6 @@ The following table shows mappings from SNOMED CT and NCI Thesaurus to of brachy
 | 3D | 434131000124108 Three dimensional conformal radiotherapy (procedure) | C16035 3-Dimensional Conformal Radiation Therapy |
 | 2D | 5304008 Conventional X-ray therapy | C165189 Conventional Radiotherapy |
 | IORT | 168524008 Radiotherapy - intraoperative control (procedure) | C15623 Intraoperative Radiotherapy |
-| Compensator | none | none |
 | PPS | none | none |
 | PSS | none | none |
 | MIX | none | none |

--- a/input/pagecontent/conformance-profiles.md
+++ b/input/pagecontent/conformance-profiles.md
@@ -6,35 +6,33 @@ Where US Core does not provide an appropriate base profile, mCODE profiles FHIR 
 
 | Profile | Based on US Core?  | Immediate Parent Profile |
 |---------|--------------------|--------------------------|
-| Brachytherapy Implantable Device | yes | US Core Implantable Device |
-| Brachytherapy Prescription Delivery | yes | US Core Procedure |
-| Cancer Disease Status | no | Observation |
-| Cancer Genetic Variant | no | US Core Laboratory Result Observation |
-| Cancer Genomics Report | yes | US Core Diagnostic Report Lab |
-| Cancer Patient | yes | US Core Patient |
-| Cancer-Related Elixhauser Comorbidities | no | Elixhauser Comorbidities |
-| Cancer-Related Medication Administration | no | Medication Administration |
-| Cancer-Related Medication Request | yes | US Core Medication Request |
-| Cancer-Related Surgical Procedure | yes | US Core Procedure |
-| Comorbidities Parent  | no | Observation |
-| Elixhauser Comorbidities | no  | Comorbidities Parent |
-| ECOG Performance Status | no | Observation |
-| Genetic Specimen | no | Specimen |
-| Genomic Region Studied | yes | US Core Laboratory Result Observation |
-| Karnofsky Performance Status | no | Observation |
-| mCODE Patient Bundle | no | Bundle  |
-| Primary Cancer Condition | yes | US Core Condition |
-| Radiotherapy Summary | yes | US Core Procedure |
-| Secondary Cancer Condition | yes | US Core Condition |
-| Teleradiotherapy Prescription Delivery | yes | US Core Procedure |
-| TNM Distant Metastases Category | no | Observation |
-| TNM Primary Tumor Category | no | Observation |
-| TNM Regional Nodes Category | no | Observation |
-| TNM Stage Group | no | Observation |
-| Tumor | no | BodyStructure |
-| Tumor Marker Test | yes | US Core Laboratory Result Observation |
-| Tumor Size | no | Observation |
-| Tumor Specimen | no | Specimen |
+| [Brachytherapy Prescription Delivery][BrachytherapyPrescriptionDelivery]| yes | US Core Procedure |
+| [Cancer Disease Status][CancerDiseaseStatus] | no | Observation |
+| [Cancer Genetic Variant][CanceGeneticVariant] | no | US Core Laboratory Result Observation |
+| [Cancer Genomics Report][CancerGenomicsReport] | yes | US Core Diagnostic Report Lab |
+| [Cancer Patient][CancerPatient] | yes | US Core Patient |
+| [Cancer-Related Medication Administration][CancerRelatedMedicationAdministration] | no | Medication Administration |
+| [Cancer-Related Medication Request][CancerRelatedMedicationRequest] | yes | US Core Medication Request |
+| [Cancer-Related Surgical Procedure][CancerRelatedSurgicalProcedure] | yes | US Core Procedure |
+| [Comorbidities Parent][ComorbiditiesParent]  | no | Observation |
+| [Elixhauser Comorbidities][ComorbiditiesElixhauser] | no | Comorbidities Parent |
+| [ECOG Performance Status][ECOGPerformanceStatus] | no | Observation |
+| [Genetic Specimen][GeneticSpecimen] | no | Specimen |
+| [Genomic Region Studied][GenomicRegionStudied] | yes | US Core Laboratory Result Observation |
+| [Karnofsky Performance Status][KarnofskyPerformanceStatus] | no | Observation |
+| [mCODE Patient Bundle][MCODEPatientBundle] | no | Bundle  |
+| [Primary Cancer Condition][PrimaryCancerCondition] | yes | US Core Condition |
+| [Radiotherapy Summary][RadiotherapySummary] | yes | US Core Procedure |
+| [Secondary Cancer Condition][SecondaryCancerCondition] | yes | US Core Condition |
+| [Teleradiotherapy Prescription Delivery][TeleradiotherapyPrescriptionDelivery] | yes | US Core Procedure |
+| [TNM Distant Metastases Category][TNMDistantMetastasesCategory] | no | Observation |
+| [TNM Primary Tumor Category][TNMPrimaryTumorCategory] | no | Observation |
+| [TNM Regional Nodes Category][TNMRegionalNodesCategory] | no | Observation |
+| [TNM Stage Group][TNMStageGroup] | no | Observation |
+| [Tumor][Tumor] | no | BodyStructure |
+| [Tumor Marker Test][TumorMarkerTest] | yes | US Core Laboratory Result Observation |
+| [Tumor Size][TumorSize] | no | Observation |
+| [Tumor Specimen][TumorSpecimen] | no | Specimen |
 {: .grid }
 
 ### Conformance to mCODE Profiles

--- a/input/pagecontent/group-patient.md
+++ b/input/pagecontent/group-patient.md
@@ -8,14 +8,13 @@ The mCODE **Patient Information** group contains the following information about
 ### Profiles
 
 * [CancerPatient]
+* [MCODEPatientBundle]
 * **Comorbidities**
   * [ComorbiditiesParent] (abstract profile)
   * [ComorbiditiesElixhauser]
-  * [CancerRelatedComorbiditiesElixhauser]
 * **Performance Status**
   * [ECOGPerformanceStatus]
   * [KarnofskyPerformanceStatus]
-* [MCODEPatientBundle]
 
 ### Extensions
 


### PR DESCRIPTION
1) Fix definitions in Brachy technique VS
2) Remove "compensator" from technique VS (move to devices; it is used with 2D technique)
3) Remove "surface-temporary" from technique VS (redundant with "surface" since no surface radiation is permanent)
4) Remove prescribedFractions from radiotherapyDose extensions (was not felt to be minimal)
5) Add "lost to followup" to TreatmentTerminationVS (TRG says this is a standard term in RCT)
6) Remove CancerRelatedComorbidity (TRG feels a second cancer can be a comorbidity w.r.t. another cancer)