### PR TITLE
Typos and rewording

### DIFF
--- a/input/pagecontent/conformance-general.md
+++ b/input/pagecontent/conformance-general.md
@@ -50,7 +50,7 @@ ALL mCODE participants MUST at minimum support the [CancerPatient] and [PrimaryC
 
 #### Support US Core Conformance Requirements
 
-Additional [conformance requirements from US Core](http://hl7.org/fhir/us/core/capstatements.html) apply to RESTful interactions, searches, and resource formats in mCODE. mCODE "inherits" all US Core conformance requirements. US Core provides base profiles for many (but not all) mCODE profiles, defines the meaning of MustSupport, and outlines expectations for handling of missing or unknown data elements. Likewise, US Core outlines how to associate provenance information associated with collection, transfer, and updating of clinical information.
+Additional [conformance requirements from US Core](http://hl7.org/fhir/us/core/capstatements.html) apply to RESTful interactions, searches, and resource formats in mCODE. mCODE "inherits" all US Core conformance requirements. US Core provides base profiles for many (but not all) mCODE profiles, outlines expectations for handling of missing or unknown data elements, and outlines how to associate provenance information associated with collection, transfer, and updating of clinical information.
 
 International users of mCODE may find US Core an impediment to implementation. Application of mCODE to other countries is open to further discussion.
 

--- a/input/pagecontent/conformance-patients.md
+++ b/input/pagecontent/conformance-patients.md
@@ -4,59 +4,64 @@ However, due to technical, organizational, or legal reasons, mCODE Data Senders 
 
 All mCODE Data Senders MUST respond to `GET [base]/Group?code=mcode-patient` with either zero or one Group resource. If no Group resource is returned, all patients with cancer diagnoses (as defined above) will be considered to be "mCODE Patients." If a Group resource is returned, patients not referenced in the Group resource are assumed to be out of scope, independent of any cancer diagnosis. This requirement is reflected in ALL CapabilityStatements referenced in this section.
 
-The following CapabilityStatements define the various methods participants can use to identify mCODE Patients. Participants implementing a pull architecture MUST support at least one of the CapabilityStatements listed from **most to least preferable** below:
+The following CapabilityStatements define the various methods participants can use to identify mCODE Patients. Participants implementing a pull architecture MUST support at least one of the CapabilityStatements listed from **most to least preferable**, below.
 
-1. **Patients-in-group** approach (CapabilityStatements for the [sender][mcode-sender-patients-in-group] and [receiver][mcode-receiver-patients-in-group]):
+### Patients-in-group Approach
 
-    Senders respond to the following request with a Group resource referencing the Patient resources for all mCODE Patients, AND allow the Receiver to retrieve a Bundle of the Patient resources referenced in the first response using [composite search parameters](https://www.hl7.org/fhir/search.html#combining):
+Senders respond to the following request with a Group resource referencing the Patient resources for all mCODE Patients, AND allow the Receiver to retrieve a Bundle of the Patient resources referenced in the first response using [composite search parameters](https://www.hl7.org/fhir/search.html#combining):
 
-        GET [base]/Group?code=mcode-patients
+    GET [base]/Group?code=mcode-patients
 
-        GET [base]/Patient?_id=some_patient_id_1,some_patient_id_2,...,some_patient_id_n
+    GET [base]/Patient?_id=some_patient_id_1,some_patient_id_2,...,some_patient_id_n
 
-    <!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
-    <div style="text-align: center;">{%include patients-in-group.svg%}</div>
+<!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
+<div style="text-align: center;">{%include patients-in-group.svg%}</div>
 
-1. **Patients-with-cancer-condition** approach (CapabilityStatements for the [sender][mcode-sender-patients-with-cancer-condition] and [receiver][mcode-receiver-patients-with-cancer-condition]):
+**CapabilityStatements:**
+* Sender: [mcode-sender-patients-in-group]
+* Receiver: [mcode-receiver-patients-in-group]
 
-    Senders respond to the following request with a Bundle of Patient resources for all mCODE Patients. This method is preferred over the approaches below UNLESS [reverse chaining](https://www.hl7.org/fhir/search.html#has) is entirely unsupported on the system.
+### Patients-with-cancer-condition Approach
 
-        GET [base]/Patient?_has:Condition:subject:code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs
+Senders respond to the following request with a Bundle of Patient resources for all mCODE Patients. This method is preferred over the approaches below UNLESS [reverse chaining](https://www.hl7.org/fhir/search.html#has) is entirely unsupported on the system.
 
-    <!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
-    <div style="text-align: center;">{%include patients-with-cancer-condition.svg%}</div>
+    GET [base]/Patient?_has:Condition:subject:code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs
 
-1.  **Patient-then-cancer-conditions** approach (CapabilityStatements for the [sender][mcode-sender-patients-and-cancer-conditions] and [receiver][mcode-receiver-patients-and-cancer-conditions]):
+<!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
+<div style="text-align: center;">{%include patients-with-cancer-condition.svg%}</div>
 
-    Senders can respond to a request using [`_include`](https://www.hl7.org/fhir/search.html#revinclude) to get a Bundle of the relevant Patient resources along with the subset of Condition resources with `Condition.code` in [Primary or Uncertain Behavior Cancer Disorder Value Set][PrimaryOrUncertainBehaviorCancerDisorderVS] in a single request. Preferred over the approach below UNLESS `_include` is entirely unsupported on the system.
+**Capability Statements:**
+* Sender: [mcode-sender-patients-with-cancer-condition]
+* Receiver: [mcode-receiver-patients-with-cancer-condition]
 
-        GET [base]/Condition?code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs&_include=Condition:subject
 
-    <!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
-    <div style="text-align: center;">{%include patients-and-cancer-conditions.svg%}</div>
+### Patient-then-cancer-conditions Approach
 
-1. **Conditions-then-patients** approach (CapabilityStatements for the [sender][mcode-sender-cancer-conditions-then-patients] and [receiver][mcode-receiver-cancer-conditions-then-patients]):
+Senders can respond to a request using [`_include`](https://www.hl7.org/fhir/search.html#revinclude) to get a Bundle of the relevant Patient resources along with the subset of Condition resources with `Condition.code` in [Primary or Uncertain Behavior Cancer Disorder Value Set][PrimaryOrUncertainBehaviorCancerDisorderVS] in a single request. Preferred over the approach below UNLESS `_include` is entirely unsupported on the system.
 
-    Senders return a Bundle with the subset of Condition resources with a `code` in the [Primary or Uncertain Behavior Cancer Disorder Value Set][PrimaryOrUncertainBehaviorCancerDisorderVS] in a single request, AND allow the Receiver to retrieve a Bundle of the Patient resources referenced in the first response using [composite search parameters](https://www.hl7.org/fhir/search.html#combining):
+    GET [base]/Condition?code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs&_include=Condition:subject
 
-        GET [base]/Condition?code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs
+<!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
+<div style="text-align: center;">{%include patients-and-cancer-conditions.svg%}</div>
 
-        GET [base]/Patient?_id=some_patient_id_1,some_patient_id_2,...,some_patient_id_n
+**Capability Statements:**
+* Sender: [mcode-sender-patients-and-cancer-conditions]
+* Receiver: [mcode-receiver-patients-and-cancer-conditions]
 
-    <!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
-    <div style="text-align: center;">{%include cancer-conditions-then-patients.svg%}</div>
+### Conditions-then-patients Approach
 
-### Capability Statements
+Senders return a Bundle with the subset of Condition resources with a `code` in the [Primary or Uncertain Behavior Cancer Disorder Value Set][PrimaryOrUncertainBehaviorCancerDisorderVS] in a single request, AND allow the Receiver to retrieve a Bundle of the Patient resources referenced in the first response using [composite search parameters](https://www.hl7.org/fhir/search.html#combining):
 
-* **Receiver**
-  * [mcode-receiver-cancer-conditions-then-patients]
-  * [mcode-receiver-patients-and-cancer-conditions]
-  * [mcode-receiver-patients-in-group]
-  * [mcode-receiver-patients-with-cancer-condition]
-* **Sender**  
-  * [mcode-sender-cancer-conditions-then-patients]
-  * [mcode-sender-patients-and-cancer-conditions]
-  * [mcode-sender-patients-in-group]
-  * [mcode-sender-patients-with-cancer-condition]
+    GET [base]/Condition?code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs
 
-    {% include markdown-link-references.md %}
+    GET [base]/Patient?_id=some_patient_id_1,some_patient_id_2,...,some_patient_id_n
+
+<!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
+<div style="text-align: center;">{%include cancer-conditions-then-patients.svg%}</div>
+
+**Capability Statements:**
+
+* Sender: [mcode-sender-cancer-conditions-then-patients]
+* Receiver: [mcode-receiver-cancer-conditions-then-patients]
+
+{% include markdown-link-references.md %}

--- a/input/pagecontent/conformance-patients.md
+++ b/input/pagecontent/conformance-patients.md
@@ -6,62 +6,68 @@ All mCODE Data Senders MUST respond to `GET [base]/Group?code=mcode-patient` wit
 
 The following CapabilityStatements define the various methods participants can use to identify mCODE Patients. Participants implementing a pull architecture MUST support at least one of the CapabilityStatements listed from **most to least preferable**, below.
 
-### Patients-in-group Approach
+### Patients-in-Group Approach
 
-Senders respond to the following request with a Group resource referencing the Patient resources for all mCODE Patients, AND allow the Receiver to retrieve a Bundle of the Patient resources referenced in the first response using [composite search parameters](https://www.hl7.org/fhir/search.html#combining):
+In this approach, Senders respond to the following request with a Group resource referencing the Patient resources for all mCODE Patients, AND allow the Receiver to retrieve a Bundle of the Patient resources referenced in the first response using [composite search parameters](https://www.hl7.org/fhir/search.html#combining):
 
     GET [base]/Group?code=mcode-patients
 
     GET [base]/Patient?_id=some_patient_id_1,some_patient_id_2,...,some_patient_id_n
 
-<!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
-<div style="text-align: center;">{%include patients-in-group.svg%}</div>
-
 **CapabilityStatements:**
 * Sender: [mcode-sender-patients-in-group]
 * Receiver: [mcode-receiver-patients-in-group]
 
-### Patients-with-cancer-condition Approach
+<!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
+<div style="text-align: center;">{%include patients-in-group.svg%}</div>
 
-Senders respond to the following request with a Bundle of Patient resources for all mCODE Patients. This method is preferred over the approaches below UNLESS [reverse chaining](https://www.hl7.org/fhir/search.html#has) is entirely unsupported on the system.
+
+### Patients-With-Cancer-Condition Approach
+
+In this approach, Senders respond to the following request with a FHIR Bundle of Patient resources for all mCODE Patients. This method is preferred over the approaches below UNLESS [reverse chaining](https://www.hl7.org/fhir/search.html#has) is entirely unsupported on the system.
 
     GET [base]/Patient?_has:Condition:subject:code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs
+
+**Capability Statements:**
+
+* Sender: [mcode-sender-patients-with-cancer-condition]
+* Receiver: [mcode-receiver-patients-with-cancer-condition]
 
 <!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
 <div style="text-align: center;">{%include patients-with-cancer-condition.svg%}</div>
 
-**Capability Statements:**
-* Sender: [mcode-sender-patients-with-cancer-condition]
-* Receiver: [mcode-receiver-patients-with-cancer-condition]
 
+### Patient-Then-Cancer-Conditions Approach
 
-### Patient-then-cancer-conditions Approach
-
-Senders can respond to a request using [`_include`](https://www.hl7.org/fhir/search.html#revinclude) to get a Bundle of the relevant Patient resources along with the subset of Condition resources with `Condition.code` in [Primary or Uncertain Behavior Cancer Disorder Value Set][PrimaryOrUncertainBehaviorCancerDisorderVS] in a single request. Preferred over the approach below UNLESS `_include` is entirely unsupported on the system.
+In this approach, Senders can respond to a request using [`_include`](https://www.hl7.org/fhir/search.html#revinclude) to get a Bundle of the relevant Patient resources along with the subset of Condition resources with `Condition.code` in [Primary or Uncertain Behavior Cancer Disorder Value Set][PrimaryOrUncertainBehaviorCancerDisorderVS] in a single request. Preferred over the approach below UNLESS `_include` is entirely unsupported on the system.
 
     GET [base]/Condition?code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs&_include=Condition:subject
+
+
+**Capability Statements:**
+
+* Sender: [mcode-sender-patients-and-cancer-conditions]
+* Receiver: [mcode-receiver-patients-and-cancer-conditions]
 
 <!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
 <div style="text-align: center;">{%include patients-and-cancer-conditions.svg%}</div>
 
-**Capability Statements:**
-* Sender: [mcode-sender-patients-and-cancer-conditions]
-* Receiver: [mcode-receiver-patients-and-cancer-conditions]
 
-### Conditions-then-patients Approach
+### Conditions-Then-Patients Approach
 
-Senders return a Bundle with the subset of Condition resources with a `code` in the [Primary or Uncertain Behavior Cancer Disorder Value Set][PrimaryOrUncertainBehaviorCancerDisorderVS] in a single request, AND allow the Receiver to retrieve a Bundle of the Patient resources referenced in the first response using [composite search parameters](https://www.hl7.org/fhir/search.html#combining):
+In this approach, Senders return a Bundle with the subset of Condition resources with a `code` in the [Primary or Uncertain Behavior Cancer Disorder Value Set][PrimaryOrUncertainBehaviorCancerDisorderVS] in a single request, AND allow the Receiver to retrieve a Bundle of the Patient resources referenced in the first response using [composite search parameters](https://www.hl7.org/fhir/search.html#combining):
 
     GET [base]/Condition?code:in=http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs
 
     GET [base]/Patient?_id=some_patient_id_1,some_patient_id_2,...,some_patient_id_n
 
-<!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
-<div style="text-align: center;">{%include cancer-conditions-then-patients.svg%}</div>
-
 **Capability Statements:**
 
 * Sender: [mcode-sender-cancer-conditions-then-patients]
 * Receiver: [mcode-receiver-cancer-conditions-then-patients]
+
+<!-- If the image below is not wrapped in a div tag, the publisher tries to wrap text around the image, which is not desired. -->
+<div style="text-align: center;">{%include cancer-conditions-then-patients.svg%}</div>
+
 
 {% include markdown-link-references.md %}

--- a/input/pagecontent/conformance-profiles.md
+++ b/input/pagecontent/conformance-profiles.md
@@ -37,25 +37,25 @@ Where US Core does not provide an appropriate base profile, mCODE profiles FHIR 
 
 ### Conformance to mCODE Profiles
 
-Each mCODE profile expresses requirements and expectations for FHIR instances in terms of structural constraints and terminology bindings. If an instance is required to conform with an mCODE profile, it MUST [validate](https://www.hl7.org/fhir/validation.html) against that profile. Only certain FHIR instances associated with an [mCODE Patient](conformance-patients.html) carry mCODE conformance expectations.
+Each mCODE profile expresses requirements and expectations for FHIR instances in terms of structural constraints and terminology bindings. If an instance is required to conform with an mCODE profile, it MUST [validate](https://www.hl7.org/fhir/validation.html) against that profile.
 
 #### Data Sender Expectations
 
-Each mCODE profile has a conformance statement describing what data or FHIR instances MUST or SHOULD conform to it. For example, in [PrimaryCancerCondition], the conformance requirements are expressed in two parts:
+Each mCODE profile has a conformance statement describing what data or FHIR instances MUST or SHOULD conform to it. The Data Sender has the responsibility for creating conformant instances. For example, in [PrimaryCancerCondition], the conformance requirements are expressed in two parts:
 
 1. Any Condition resource associated with an [mCODE Patient](conformance-patients.html) whose `Condition.code` is in the value set `[PrimaryOrUncertainBehaviorCancerDisorderVS]` MUST conform to the profile.
 2. Any resource instance that would reasonably be expected to conform to the profile SHOULD conform to the profile.
 
-The second statement is intended to discourage an mCODE Data Sender from creating different representation for data that *should* fall into the scope of mCODE. Compliance to this kind of condition is admittedly difficult to enforce, so it is expressed as a SHOULD.
+The second statement is intended to discourage an mCODE Data Sender from creating different representation for data that *should* fall into the scope of mCODE. Compliance to this kind of condition is difficult to enforce, so it is expressed as a SHOULD.
 
 #### Data Receiver Expectations
 
-An mCODE Data Receiver SHOULD perform validation on instances it receives. The Receiver first of all needs to identify which profile to use for validation. There four ways to identify the correct profile:
+An mCODE Data Receiver SHOULD perform validation on instances it receives. There are four ways the Receiver can identify the profile to use for validation:
 
 1. The instance is received in response to a [profile search](https://www.hl7.org/fhir/search.html#profile), so the validating profile is known in advance.
-2. The instance self-identifies using `meta.profile`. Every Data Sender SHOULD populate this element.
-3. The Data Receiver can examine the contents of the instance to associate it with a profile (in particular, by looking for identifying code or category).
-4. The Data Receiver can iteratively attempt to validate the instance against each of the Data Receiver's supported profiles.
+2. The instance self-identifies an mCODE profile using `meta.profile`. Every Data Sender SHOULD populate this element.
+3. The Data Receiver examines the contents of the instance to associate it with a profile (in particular, by looking for an identifying code or category).
+4. The Data Receiver iteratively tries to validate against each of its supported profiles applicable to the instance's resource type.
 
 If an instance fails validation, the Receiver may reject the instance.
 
@@ -63,14 +63,14 @@ If an instance fails validation, the Receiver may reject the instance.
 
 #### Sender and Receiver Expectations
 
-For every element that is [required](#required-elements) and/or carries a [Must Support obligation](#must-support-obligations) (MS):
+For every element that is [required](#required-elements) and/or carries a [Must Support (MS) obligation](#must-support-obligations):
 
-* mCODE Data Senders SHALL be capable of populating the element, provided the Sender supports the profile (as indicated by its CapabilityStatement).
+* mCODE Data Senders SHALL be capable of populating the element, provided the Sender supports the profile (as indicated in its CapabilityStatement).
 * If the Sender lacks the data necessary to populate the element:
   * If the element is required, the [US Core rules on missing data](http://hl7.org/fhir/us/core/general-guidance.html#missing-data) MUST be followed.
-  * If the element is not required (but is MS), the element SHOULD be entirely omitted. If there is a specific reason the data is missing, a data absent reason MAY be substituted.
-  * Senders MUST NOT substitute a nonsense or filler value just to satisfy MS or cardinality requirement.
-* mCODE Data Receivers SHALL be capable of meaningfully processing MS elements, provided the Receiver supports the profile. Depending on context, "meaningfully process" might mean displaying the data element for human use, reacting to it, or storing it for other purposes.
+  * If the element is not required but must be supported, the element SHOULD be entirely omitted. If there is a specific reason the data is missing, a data absent reason MAY be substituted.
+  * Senders MUST NOT substitute nonsense or filler values just to satisfy [MS obligations](#must-support-obligations) or cardinality requirements.
+* mCODE Data Receivers SHALL be capable of meaningfully processing elements with [MS obligations](#must-support-obligations), provided the Receiver supports the profile. Depending on context, "meaningfully process" might mean displaying the data element for human use, reacting to it, or storing it for other purposes.
 
 #### Required Elements
 
@@ -84,20 +84,20 @@ In other words, a data element may be `1..1`, but if it is contained by an optio
 
 #### Must Support Obligations
 
-Interpretation of MS is not straightforward, as there is a difference between a MS *obligation* and a MS *flag*. The MS *flag* is the red S displayed on profile pages: <span style="padding-left: 3px; padding-right: 3px; color: white; background-color: red" >S</span>. A MS *obligation* means the element must be treated as described in [Sender and Receiver Expectations](#sender-and-receiver-expectations). Significantly, an MS *flag* (<span style="padding-left: 3px; padding-right: 3px; color: white; background-color: red" >S</span>) does not necessarily imply an MS *obligation*, and MS *obligations* may be attached to elements lacking MS *flags*.
+Interpretation of MS is not straightforward, since there is a difference between an MS *obligation* and an MS *flag*. The MS *flag* is the red S displayed on profile pages: <span style="padding-left: 3px; padding-right: 3px; color: white; background-color: red" >S</span>. An MS *obligation* means the element must be treated as described in [Sender and Receiver Expectations](#sender-and-receiver-expectations). Significantly, an MS *flag* (<span style="padding-left: 3px; padding-right: 3px; color: white; background-color: red" >S</span>) does not necessarily imply an MS *obligation*, and MS *obligations* may be attached to elements lacking MS *flags*.
 
 To see which elements have MS flags, consult the "Snapshot Table" view of the profile. The "Differential Table" view hides MS flags inherited from the parent profile. The "Snapshot Table (Must Support)" view reflects the IG Publisher's interpretation of how MS flags translate to MS obligations, which may or may not coincide with the US Core/mCODE interpretation.
 
 The following rules apply in mCODE:
 
-* A profile without a MS flag does not have to be supported [^1]. A participant MUST declare support for optional profiles in its CapabilityStatement.
+* A profile without an MS flag does not have to be supported [^1]. A participant MUST declare support for optional profiles in its CapabilityStatement.
 * Any MS flag or flags on an unsupported profile (as stated in participant's CapabilityStatement) do not carry MS obligations.
 * An element with an MS flag does not carry an MS obligation if it is nested and any one of the elements directly containing that element lacks an MS flag. However, if the participant *elects* to support the unflagged element or elements in that hierarchy, the elements below the gap then carry an MS obligation.
 * An element with an MS flag whose cardinality is 0..0 does not carry an MS obligation [^2].
-* A [required element](#required-elements) carries a MS obligation on the part of a Data Sender, regardless of whether that element has an MS flag. 
+* A [required element](#required-elements) carries an MS obligation on the part of a Data Sender, regardless of whether that element has an MS flag.
 * A [required element](#required-elements) without an MS flag does not carry an MS obligation for the Data Receiver [^3].
 
-The following explains how to interpret MS flags in certain cases involving complex elements. Requirements for Senders and Receivers for elements with MS obligations are [defined above](#sender-and-receiver-expectations). For the sake of completeness, this table covers certain cases not seen in mCODE.
+The following table explains how to interpret MS flags in certain cases involving complex elements. Requirements for Senders and Receivers for elements with MS obligations are [defined above](#sender-and-receiver-expectations). For the sake of completeness, this table covers certain cases not seen in mCODE.
 
 | # | MS-Flagged Element  | mCODE Data Sender (Server) Obligation  | mCODE Data Receiver (Client) Obligation | Example |
 |---|--------------|--------------|---------------|---|
@@ -108,16 +108,16 @@ The following explains how to interpret MS flags in certain cases involving comp
 | 5 | Element is a [choice \[x\] type](https://www.hl7.org/fhir/stu3/formats.html#choice) with no MS flag on any choice | MUST support at least one datatype choice, and SHOULD populate every datatype for which the server might possess data | MUST support **all** datatype choices (since the Receiver cannot anticipate which sub-elements might be populated)| [CancerPatient.deceased\[x\]][CancerPatient] |
 | 6 | Element is a [choice \[x\] type](https://www.hl7.org/fhir/stu3/formats.html#choice) with an MS flag on one or more choice | MUST support only the datatype choice(s) that are explicitly flagged | same |  [US Core Laboratory Result Observation Profile version 3.2](http://hl7.org/fhir/us/core/3.2.0/StructureDefinition-us-core-observation-lab.html) Observation.value[x] |
 | 7 | Element is a [Reference() data type](https://www.hl7.org/fhir/references.html#2.3.0) with no MS flag on any referenced resource or profile | MUST support all resources or profiles in the reference that are in Sender's capability statement | MUST support all resources or profiles in the reference unless outside the scope of the Receiver's capability statement | [Tumor.extension\[mcode-condition-related\].value\[x\]][Tumor] |
-| 8 | Element is a [Reference() data type](https://www.hl7.org/fhir/references.html#2.3.0) with an MS flag on one or more of the referenced types | MUST support only the resources or profiles in the reference that are explicitly flagged, and only if they are in the Sender's capability statement | MUST support only the resources or profiles in the reference that are explicitly flagged, and only if they are in the Receiver's capability statement | [US Core DocumentReference Profile version 3.2](http://hl7.org/fhir/us/core/3.2.0/StructureDefinition-us-core-documentreference.html) DocumentReference.author
-| 9 | Element is a [backbone data type](https://www.hl7.org/fhir/backboneelement.html#2.29.0) | No support expectation on sub-elements unless they are explicitly flagged  | same |
+| 8 | Element is a [Reference() data type](https://www.hl7.org/fhir/references.html#2.3.0) with an MS flag on one or more of the referenced types | MUST support only the resources or profiles in the reference that are explicitly flagged, and only if they are in the Sender's capability statement | MUST support only the resources or profiles in the reference that are explicitly flagged, and only if they are in the Receiver's capability statement | [US Core DocumentReference Profile version 3.2](http://hl7.org/fhir/us/core/3.2.0/StructureDefinition-us-core-documentreference.html) DocumentReference.author |
+| 9 | Element is a [backbone data type](https://www.hl7.org/fhir/backboneelement.html#2.29.0) | No support expectation on sub-elements unless they are explicitly flagged  | same | |
 | 10 | Element is an [array that is sliced](https://www.hl7.org/fhir/profiling.html#slicing), with no MS flag on any slice | MUST support populating the array, but [no obligation to support any particular slice](https://confluence.hl7.org/pages/viewpage.action?pageId=35718826#GuidetoDesigningResources-HowdoIinterpret'MustSupport'withrespecttoslicing?) | MUST support arbitrary array contents, including any and all populated slices |
 | 11 | Element is an [array that is sliced](https://www.hl7.org/fhir/profiling.html#slicing), with MS flags on one or more slices | MUST support only the slices that have MS flags | same | [TNMStageGroup].hasMember |
-| 12 | Element that has MS flag is a slice and the containing array does not have a MS flag | No support expectation for the slice | same | [US Core Patient Profile version 3.1.1](http://hl7.org/fhir/us/core/StructureDefinition-us-core-patient.html) Patient.extension:us-core-race (because Patient.extension is not MS)
+| 12 | Element that has MS flag is a slice and the containing array does not have an MS flag | No support expectation for the slice | same | [US Core Patient Profile version 3.1.1](http://hl7.org/fhir/us/core/StructureDefinition-us-core-patient.html) Patient.extension:us-core-race (because Patient.extension is not MS) |
 {: .grid }
 
 #### Non-Must Support Elements
 
-Data elements in mCODE that *do not have* MS obligations still MAY be supported. If an element is supported, whether it has a MS flag or not, the profile must be interpreted as if the MS flag were present. For example, `TumorMarkerTest.performer` does not have an MS flag, but a data receiver may implement the capability to display it. In such a case, by virtue of the fact this element is a Reference() data type with no MS flag on any referenced resource or profile (case #7 above), the receiver would be obligated to support all resources or profiles in the Reference unless outside the scope of the Receiver's capability statement, namely, Practitioner, PractitionerRole, Organization, CareTeam, Patient, and RelatedPerson.
+Data elements in mCODE that *do not have* MS obligations MAY be supported. If an element is supported, whether it has an MS flag or not, the profile must be interpreted as if the MS flag were present. For example, `TumorMarkerTest.performer` does not have an MS flag, but a data receiver may implement the capability to display it. In such a case, by virtue of the fact this element is a Reference() data type with no MS flag on any referenced resource or profile (case #7 above), the receiver would be obligated to support all resources or profiles in the Reference unless outside the scope of the Receiver's capability statement, namely, Practitioner, PractitionerRole, Organization, CareTeam, Patient, and RelatedPerson.
 
 [^1]: Although not common practice, profiles can have MS flags at the very top level (see [CancerPatient] for example).
 

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -1,10 +1,8 @@
 ### Data Dictionary
 
-The Data Dictionary presents mCODE's content in a format that may be more accessible than the default FHIR artifact pages. The Data Dictionary is a Excel spreadsheet that lists mCODE data elements and some details about them.
+The Data Dictionary presents mCODE's content in a format that may be more accessible than the default FHIR artifact pages. The Data Dictionary is a Excel spreadsheet that lists mCODE data elements and some details about them. If there is a discrepancy between the Data Dictionary and the FHIR artifacts, the FHIR artifacts are taken as the source of truth.
 
-If there is a discrepancy between the Data Dictionary and the FHIR artifacts, the FHIR artifacts are taken as the source of truth.
-
-The Data Dictionary is a *partial listing* of data elements. Please be aware of the following:
+The DD intentionally omits certain elements in FHIR that are not expected to be implemented. Please be aware of the following:
 
 * **Profiles not shown in data dictionary:** Not all profiles used by mCODE are included in the Data Dictionary. mCODE uses external profiles for vital signs and routine laboratory results. These profiles are not included in the Data Dictionary because they are defined externally to mCODE.
 

--- a/input/pagecontent/group-disease.md
+++ b/input/pagecontent/group-disease.md
@@ -48,6 +48,12 @@ Body locations in FHIR are typically represented using a single code. However, a
 
 mCODE has adopted an approach that allows the user to add additional code or codes to further define the body site, without the need to create an independent resource. This takes the form of a [LocationQualifier] extension. This extension can be used to specify laterality, directionality, and plane. It appears in mCODE wherever a body site code is found.
 
+### Tumor Marker Tests
+
+Tumor markers are key prognostic factors in calculating cancer staging, identifying treatment options, and monitoring progression of disease. For example, an abnormal increase in prostate-specific antigen (PSA) levels is a prognostic factor for prostate cancer. Other tumor markers include estrogen receptor (ER) status, progesterone receptor (PR) status, carcinoembryonic antigen (CEA) levels, among others. mCODE distinguishes tumor marker tests from sequencing-based genomic tests measured at the DNA, RNA, or chromosomal level. The latter are addressed in the [Genomics](group-genomics.html) section.
+
+mCODE includes single FHIR profile, [TumorMarkerTest], for all labs involving serum and tissue-based tumor markers. This is less than ideal, since without specifying units of measure or answer sets on a per-test basis, reporting could vary. However, given the large number of tumor marker tests, creating individual profiles was judged impractical.
+
 ### Profiles
 
 * Diagnosis
@@ -58,6 +64,8 @@ mCODE has adopted an approach that allows the user to add additional code or cod
   * [TNMPrimaryTumorCategory]
   * [TNMRegionalNodesCategory]
   * [TNMDistantMetastasesCategory]
+* Characterization
+  * [TumorMarkerTest]
 
 ### Extensions
 
@@ -82,5 +90,7 @@ mCODE has adopted an approach that allows the user to add additional code or cod
   * [TNMPrimaryTumorCategoryVS]
   * [TNMRegionalNodesCategoryVS]
   * [TNMDistantMetastasesCategoryVS]
+* **Characterization**
+  * [TumorMarkerTestVS]
 
 {% include markdown-link-references.md %}

--- a/input/pagecontent/group-genomics.md
+++ b/input/pagecontent/group-genomics.md
@@ -7,11 +7,6 @@ mCODE includes genomics-related data elements needed inform cancer assessment an
 
 The identity of non-genomic laboratory tests is typically represented by a [Logical Observation Identifiers and Names (LOINC)](https://loinc.org/) code. However, many genetic tests and panels do not have LOINC codes, although some might have an identifier in the [NCBI Genetic Testing Registry (GTR)](https://www.ncbi.nlm.nih.gov/gtr/), a central location for voluntary submission of genetic test information by providers. While GTR is a viable source for identifying many genetic tests, the user should be aware that the GTR is not single authoritative source since the test data is voluntarily updated. Standardization of codes for genetic tests is essential to facilitate data analysis of genetic tests, and should be a priority for the genomics testing community in the near future. Implementers should also note that, to conform to the requirements of the [US Core Laboratory Result Profile](http://hl7.org/fhir/us/core/StructureDefinition-us-core-observation-lab.html), if a suitable LOINC exists, it must be used. If there is no suitable code in LOINC, then a code from an alternative code system such as GTR can be used.
 
-### Tumor Marker Tests
-
-Tumor markers are key prognostic factors in calculating cancer staging, identifying treatment options, and monitoring progression of disease. For example, an abnormal increase in prostate-specific antigen (PSA) levels is a prognostic factor for prostate cancer. Other tumor markers include estrogen receptor (ER) status, progesterone receptor (PR) status, carcinoembryonic antigen (CEA) levels, among others. mCODE distinguishes tumor marker tests from sequencing-based genomic tests measured at the DNA, RNA, or chromosomal level. The latter are addressed in the [Genomics](group-genomics.html) section.
-
-mCODE includes single FHIR profile, [TumorMarkerTest], for all labs involving serum and tissue-based tumor markers. This is less than ideal, since without specifying units of measure or answer sets on a per-test basis, reporting could vary. However, given the large number of tumor marker tests, creating individual profiles was judged impractical.
 
 ### Profiles
 
@@ -19,7 +14,6 @@ mCODE includes single FHIR profile, [TumorMarkerTest], for all labs involving se
 * [GeneticSpecimen]
 * [CancerGenomicsReport]
 * [GenomicRegionStudied]
-* [TumorMarkerTest]
 
 ### Value Sets
 
@@ -28,6 +22,5 @@ mCODE includes single FHIR profile, [TumorMarkerTest], for all labs involving se
 * [GeneticSpecimenTypeVS]
 * [HGNCVS]
 * [HGVSVS]
-* [TumorMarkerTestVS]
 
 {% include markdown-link-references.md %}

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -7,7 +7,7 @@ Please review the STU2 changes listed in the [mCODE FHIR IG Change Log](change_l
 
 ### Background
 
-According to the National Cancer Institute, 38.5 percent of men and women will be diagnosed with cancer at some point during their lifetimes. In 2014, an estimated 14.7M people were living with cancer in the United States. While these numbers are staggering, the silver lining in the wide prevalence of cancer is the potential to learn from treatment of millions of patients. If we had research-quality data from all cancer patients, it would enable higher quality health outcomes. Today, we lack the data models, technologies, and methods to capture that data.
+Cancer is among the leading causes of death worldwide. According to the National Cancer Institute, in the United States, 39.5 percent of men and women will be diagnosed with cancer at some point during their lifetimes. In 2020, an estimated 1,806,590 new cases of cancer will be diagnosed in the United States and 606,520 people will die from the disease. While these numbers are staggering, the silver lining in the wide prevalence of cancer is the potential to learn from treatment of millions of patients. If we had research-quality data from all cancer patients, it would enable higher quality health outcomes. Today, we lack the data models, technologies, and methods to capture that data.
 
 [mCODE™](https://mcodeinitiative.org/) (short for Minimal Common Oncology Data Elements) is an initiative intended to assemble a core set of structured data elements for oncology electronic health records (EHRs). mCODE is a step towards capturing research-quality data from the treatment of all cancer patients. This would enable the treatment of every cancer patient to contribute to [comparative effectiveness analysis (CEA)](https://en.wikipedia.org/wiki/Comparative_effectiveness_research) of cancer treatments by allowing for easier methods of data exchange between health systems. mCODE has been created and is being supported by the [American Society of Clinical Oncology (ASCO®)](https://www.asco.org/)in collaboration with the MITRE Corporation.
 
@@ -34,8 +34,6 @@ In addition to information obtained from subject matter experts, several pre-exi
 
 After initial development, in early 2019, an open survey was conducted to validate and prioritize the data elements from these use cases. Further down-scoping was done based on whether the data would be stored or capture in an electronic health record (EHR), and if it would place undue documentation burden on clinicians.
 
-What follows is an overview of mCODE, directed primarily at clinical readers. Readers should also take note of the [Data Dictionary (Excel download)](mCODEDataDictionary.xlsx), a simplified, flattened list of mCODE elements.
-
 ### Scope and Conceptual Model
 
 This implementation guide is a Domain of Knowledge IG. The purpose of this IG is to show how to represent clinical concepts generally, not to have a complete set of agreements for interoperable exchanges.
@@ -57,9 +55,10 @@ The groups are illustrated in the following diagram:
 
 ### Data Dictionary
 
-The [Data Dictionary (DD)](mCODEDataDictionary.xlsx) includes only the must-support elements in the mCODE specification, intentionally omitting certain elements in FHIR that are not expected to be implemented. In the event there are differences between the DD and the FHIR implementation guide, the FHIR artifacts in the IG should be taken as the source of truth.
+In addition to the FHIR artifacts, readers should also take note of the [Data Dictionary (Excel download)](mCODEDataDictionary.xlsx), a simplified, flattened list of mCODE elements.
 
-The STU 2 DD is somewhat different than the STU 1 version. The STU 2 DD lists significantly more data elements. In STU 1, some data elements were suppressed because they were common to most or all profiles, such as the reference to patient or subject, or the time of resource creation. However, the redaction of certain elements proved confusing, so the current DD does not continue this practice. Many of the "extra" rows are not new at all, but are due to this change.
+The STU 2 DD is somewhat different than the STU 1 version. In STU 1, some data elements were suppressed because they were common to most or all profiles, such as the patient, provider, status, and date. However, the redaction of certain elements proved confusing, so the current DD does not continue this practice. As a result, the STU 2 DD lists significantly more data elements.  Many of the "extra" rows are not new at all, but reflect the inclusion of elements redacted in STU 1.
+{:.new-content}
 
 ### Understanding this Guide
 
@@ -71,7 +70,7 @@ In the event there are differences between the page renderings in this IG and th
 
 The authors recognize the leadership and sponsorship of Dr. Monica Bertagnolli, former ASCO President and Dr. Jay Schnitzer, MITRE Chief Technology Officer. Dr. Steven Piantadosi and the Alliance for Clinical Trials in Oncology coordinated real-world data collection in clinical trials, as part of this project. The ASCO/CancerLinQ team was led by Dr. Robert Miller. Lead MITRE contributors were Mark Kramer, May Terry, Max Masnick, Rute Martins, Chris Moesel, and Caroline Potteiger. Andre Quina and Dr. Brian Anderson guided the overall mCODE effort at MITRE. HL7 sponsorship and input from [Clinical Interoperability Council](http://www.hl7.org/Special/committees/cic/index.cfm) and [Clinical Information Modeling Initiative](https://www.hl7.org/Special/Committees/cimi/index.cfm) is gratefully acknowledged, with special thanks to Richard Esmond and Laura Heermann Langford.
 
-This IG was authored by the MITRE Corporation using [FHIR Shorthand (FSH)](http://hl7.org/fhir/uv/shorthand/) and [SUSHI](https://fshschool.org), a free, open source toolchain from [MITRE Corporation](https://www.mitre.org/).
+This IG was authored by the MITRE Corporation using [FHIR Shorthand (FSH)](http://hl7.org/fhir/uv/shorthand/) and [SUSHI](https://fshschool.org), a free, open source tool-chain from [MITRE Corporation](https://www.mitre.org/).
 
 ### Contact Information
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -1,6 +1,6 @@
 id: hl7.fhir.us.mcode
 canonical: http://hl7.org/fhir/us/mcode
-version: 1.6.0
+version: 1.7.0
 name: MinimalCommonOncologyDataElements
 title: "minimal Common Oncology Data Elements (mCODE) Implementation Guide"
 status: draft


### PR DESCRIPTION
1) Reformatted the conformance-patients.md page
2) A few typos and rewording on conformance-profiles.md page
3) Upped the version to 1.7.0
4) Moved TumorMarkerTest to Disease group (per discussion with May)