### PR TITLE
Code system canonical url

### DIFF
--- a/FHIR-us-mcode.xml
+++ b/FHIR-us-mcode.xml
@@ -76,7 +76,7 @@
 <artifact id="ValueSet/elixhauser-drug-abuse-vs" key="ValueSet-elixhauser-drug-abuse-vs" name="Elixhauser Comorbid Condition Value Set for drug abuse"/>
 <artifact id="ValueSet/elixhauser-cancer-solid-tumor-in-situ-vs" key="ValueSet-elixhauser-cancer-solid-tumor-in-situ-vs" name="Elixhauser Comorbid Condition Value Set for malignant solid tumors in situ"/>
 <artifact id="ValueSet/elixhauser-cancer-solid-tumor-malignant-vs" key="ValueSet-elixhauser-cancer-solid-tumor-malignant-vs" name="Elixhauser Comorbid Condition Value Set for malignant solid tumors without metastases"/>
-<artifact id="CodeSystem/mcode-comorbidities-elixhauser-ahrq-cs" key="CodeSystem-mcode-comorbidities-elixhauser-ahrq-cs" name="Elixhauser Comorbidity Category"/>
+<artifact id="CodeSystem/comorbidities-elixhauser" key="CodeSystem-comorbidities-elixhauser" name="Elixhauser Comorbidity Category"/>
 <artifact id="StructureDefinition/mcode-evidence-type" key="StructureDefinition-mcode-evidence-type" name="Evidence Type"/>
 <artifact deprecated="true" id="Extension/mcode-evidence-type-extension" key="evidence-type-extension" name="Evidence Type Extension"/>
 <artifact id="StructureDefinition/mcode-genetic-specimen" key="genetic-specimen" name="Genetic Specimen"/>

--- a/FHIR-us-mcode.xml
+++ b/FHIR-us-mcode.xml
@@ -105,7 +105,7 @@
 <artifact deprecated="true" key="Procedure" name="Procedure"/>
 <artifact deprecated="true" id="ValueSet/mcode-radiation-procedure-value-set" key="radiation-procedure-value-set" name="Radiation Procedure Value Set"/>
 <artifact id="ValueSet/mcode-radiation-target-body-site-vs" key="radiation-target-body-site-value-set" name="Radiation Target Body Site Value Set"/>
-<artifact id="CodeSystem/mcode-radiotherapy-cs" key="CodeSystem-mcode-radiotherapy-cs" name="Radiotherapy Code System"/>
+<artifact id="CodeSystem/radiotherapy" key="CodeSystem-radiotherapy" name="Radiotherapy Code System"/>
 <artifact id="StructureDefinition/mcode-radiotherapy-dose" key="StructureDefinition-mcode-radiotherapy-dose" name="Radiotherapy Dose"/>
 <artifact id="StructureDefinition/mcode-radiotherapy-fractions-delivered" key="StructureDefinition-mcode-radiotherapy-fractions-delivered" name="Radiotherapy Fractions Delivered"/>
 <artifact id="StructureDefinition/mcode-radiotherapy-modality" key="StructureDefinition-mcode-radiotherapy-modality" name="Radiotherapy Modality"/>

--- a/input-cache/txcache/null.cache
+++ b/input-cache/txcache/null.cache
@@ -3,20 +3,29 @@
   "resourceType" : "ValueSet",
   "compose" : {
     "include" : [{
-      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs"]
+      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-teleradiotherapy-modality-vs"]
     },
     {
-      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-secondary-cancer-disorder-vs"]
-    },
-    {
-      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs"]
-    },
-    {
-      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-histology-morphology-behavior-vs"]
+      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-brachytherapy-modality-vs"]
     }]
   }
 }}####
 e: {
-  "error" : "Error from server: Unable to find value set \"http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs\""
+  "error" : "Error from server: Unable to find value set \"http://hl7.org/fhir/us/mcode/ValueSet/mcode-teleradiotherapy-modality-vs\""
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : true, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-teleradiotherapy-technique-vs"]
+    },
+    {
+      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-brachytherapy-technique-vs"]
+    }]
+  }
+}}####
+e: {
+  "error" : "Error from server: Unable to find value set \"http://hl7.org/fhir/us/mcode/ValueSet/mcode-teleradiotherapy-technique-vs\""
 }
 -------------------------------------------------------------------------------------

--- a/input-cache/txcache/usmcodeCodeSystemmcode-catch-code-cs.cache
+++ b/input-cache/txcache/usmcodeCodeSystemmcode-catch-code-cs.cache
@@ -21,6 +21,6 @@
   }
 }}####
 e: {
-  "error" : "Error from server: Unable to provide support for code system http://hl7.org/fhir/us/mcode/CodeSystem/mcode-catch-code-cs"
+  "error" : "Error from server: Unable to find value set \"http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-or-uncertain-behavior-cancer-disorder-vs\""
 }
 -------------------------------------------------------------------------------------

--- a/input-cache/txcache/usmcodeCodeSystemmcode-radiotherapy-cs.cache
+++ b/input-cache/txcache/usmcodeCodeSystemmcode-radiotherapy-cs.cache
@@ -1,0 +1,475 @@
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "LDR"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"LDR\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#LDR) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "PDR"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"PDR\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#PDR) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "HDR"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"HDR\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#HDR) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "ELEC"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"ELEC\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#ELEC) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "PHARM"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"PHARM\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#PHARM) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "CAV"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"CAV\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#CAV) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "CAV-IMB"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"CAV-IMB\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#CAV-IMB) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "INSTIT"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"INSTIT\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#INSTIT) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "INSTIT-PERM"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"INSTIT-PERM\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#INSTIT-PERM) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "INSTIT-TEMP"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"INSTIT-TEMP\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#INSTIT-TEMP) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "VASC"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"VASC\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#VASC) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "LUM"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"LUM\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#LUM) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "IORT"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"IORT\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#IORT) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "SURF"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"SURF\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#SURF) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "ORAL"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"ORAL\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#ORAL) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "PROTON"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"PROTON\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#PROTON) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "ELECTRON"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"ELECTRON\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#ELECTRON) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "NEUTRON"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"NEUTRON\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#NEUTRON) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "CARBON"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"CARBON\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#CARBON) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "PHOTON"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"PHOTON\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#PHOTON) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "IMRT"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"IMRT\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#IMRT) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "VMAT"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"VMAT\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#VMAT) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "3D"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"3D\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#3D) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "2D"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"2D\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#2D) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "PPS"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"PPS\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#PPS) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "PSS"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"PSS\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#PSS) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "MIX"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"MIX\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#MIX) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "IMNT"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"IMNT\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#IMNT) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+  "code" : "NCT"
+}, "valueSet" :null, "lang":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"NCT\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#NCT) is not valid in the value set 'All codes known to the system' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+    "code" : "PHOTON",
+    "display" : "Photon Beam Radiation Therapy"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-teleradiotherapy-modality-vs"]
+    },
+    {
+      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-brachytherapy-modality-vs"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"PHOTON\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#PHOTON) is not valid in the value set 'RadiotherapyModalityVS' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+    "code" : "3D",
+    "display" : "Three Dimensional"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-teleradiotherapy-technique-vs"]
+    },
+    {
+      "valueSet" : ["http://hl7.org/fhir/us/mcode/ValueSet/mcode-brachytherapy-technique-vs"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs\" is not known (encountered paired with code = \"3D\"); The code provided (http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs#3D) is not valid in the value set 'RadiotherapyTechniqueVS' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : true, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+      "concept" : [{
+        "code" : "LDR"
+      },
+      {
+        "code" : "PDR"
+      },
+      {
+        "code" : "HDR"
+      },
+      {
+        "code" : "ELEC"
+      },
+      {
+        "code" : "PHARM"
+      }]
+    }]
+  }
+}}####
+e: {
+  "error" : "Error from server: Unable to provide support for code system http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs"
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : true, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+      "concept" : [{
+        "code" : "CAV"
+      },
+      {
+        "code" : "CAV-IMB"
+      },
+      {
+        "code" : "INSTIT"
+      },
+      {
+        "code" : "INSTIT-PERM"
+      },
+      {
+        "code" : "INSTIT-TEMP"
+      },
+      {
+        "code" : "VASC"
+      },
+      {
+        "code" : "LUM"
+      },
+      {
+        "code" : "IORT"
+      },
+      {
+        "code" : "SURF"
+      },
+      {
+        "code" : "ORAL"
+      }]
+    }]
+  }
+}}####
+e: {
+  "error" : "Error from server: Unable to provide support for code system http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs"
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : true, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+      "concept" : [{
+        "code" : "PROTON"
+      },
+      {
+        "code" : "ELECTRON"
+      },
+      {
+        "code" : "NEUTRON"
+      },
+      {
+        "code" : "CARBON"
+      },
+      {
+        "code" : "PHOTON"
+      }]
+    }]
+  }
+}}####
+e: {
+  "error" : "Error from server: Unable to provide support for code system http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs"
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : true, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs",
+      "concept" : [{
+        "code" : "IMRT"
+      },
+      {
+        "code" : "VMAT"
+      },
+      {
+        "code" : "3D"
+      },
+      {
+        "code" : "2D"
+      },
+      {
+        "code" : "IORT"
+      },
+      {
+        "code" : "PPS"
+      },
+      {
+        "code" : "PSS"
+      },
+      {
+        "code" : "MIX"
+      },
+      {
+        "code" : "IMNT"
+      },
+      {
+        "code" : "NCT"
+      }]
+    }]
+  }
+}}####
+e: {
+  "error" : "Error from server: Unable to provide support for code system http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs"
+}
+-------------------------------------------------------------------------------------

--- a/input/fsh/DEF_CodeSystems.fsh
+++ b/input/fsh/DEF_CodeSystems.fsh
@@ -63,7 +63,7 @@ Description: "Codes describing the modalities, techniques, and devices used in e
 
 CodeSystem: ComorbiditiesElixhauserCS
 Id: comorbidities-elixhauser
-Title: "Elixhauser Comorbidity Category"
+Title: "Elixhauser Comorbidity Categories"
 Description: "A code system that contains codes representing the comorbidity categories originally defined by Elixhauser, and updated by the Agency for Healthcare Research and Quality (AHRQ) Healthcare Cost and Utilization Project (H-CUP)."
 * ^url =  http://terminology.hl7.org/CodeSystem/comorbidities-elixhauser
 * #AIDS    "Acquired immune deficiency syndrome"

--- a/input/fsh/DEF_CodeSystems.fsh
+++ b/input/fsh/DEF_CodeSystems.fsh
@@ -1,7 +1,7 @@
-Alias: COMORB = http://hl7.org/fhir/us/mcode/CodeSystem/mcode-comorbidities-elixhauser-ahrq-cs
+Alias: COMORB =  http://terminology.hl7.org/CodeSystem/comorbidities-elixhauser
 Alias: RID = http://hl7.org/fhir/us/mcode/CodeSystem/mcode-resource-identifier-cs
 Alias: CC = http://hl7.org/fhir/us/mcode/CodeSystem/mcode-catch-code-cs
-Alias: RT = http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs
+Alias: RT = http://terminology.hl7.org/CodeSystem/radiotherapy
 
 CodeSystem: CatchCodeCS
 Id: mcode-catch-code-cs
@@ -23,9 +23,10 @@ Description: "Concepts describing types of instances, to be used in the 'code' e
 * #mcode-radiotherapy-brachy "Brachytherapy Prescription Delivery Resource" "Identifies an Observation resource that describes delivery of a brachytherapy (external beam) prescription and conforms to the BrachytherapyPrescriptionDelivery profile."
 
 CodeSystem: RadiotherapyCS
-Id: mcode-radiotherapy-cs
+Id: radiotherapy
 Title: "Radiotherapy Code System"
 Description: "Codes describing the modalities, techniques, and devices used in external beam radiotherapy and brachytherapy procedures."
+* ^url =  http://terminology.hl7.org/CodeSystem/radiotherapy
 //-- Teleradiotherapy Modalities
 * #PROTON "Proton Beam Radiation Therapy" "A type of external beam radiation therapy using a beam of proton particles." 
 * #ELECTRON "Electron Beam Radiation Therapy"  "Radiation therapy using electron (beta particle) beam."
@@ -60,10 +61,11 @@ Description: "Codes describing the modalities, techniques, and devices used in e
 * #VASC "Intravascular" "Placement of a radioactive source into a blood vessel or blood vascular system or vascular injection of radiopharaceutical."
 * #ORAL "Oral"  "Ingestion of radiopharaceutical via oral route."
 
-CodeSystem: ComorbiditiesElixhauserAHRQCS
-Id: mcode-comorbidities-elixhauser-ahrq-cs
+CodeSystem: ComorbiditiesElixhauserCS
+Id: comorbidities-elixhauser
 Title: "Elixhauser Comorbidity Category"
 Description: "A code system that contains codes representing the comorbidity categories originally defined by Elixhauser, and updated by the Agency for Healthcare Research and Quality (AHRQ) Healthcare Cost and Utilization Project (H-CUP)."
+* ^url =  http://terminology.hl7.org/CodeSystem/comorbidities-elixhauser
 * #AIDS    "Acquired immune deficiency syndrome"
 * #ALCOHOL    "Alcohol abuse" 
 * #ANEMDF    "Deficiency anemias"

--- a/input/includes/markdown-link-references.md
+++ b/input/includes/markdown-link-references.md
@@ -123,8 +123,8 @@
 [TumorSizeUnitsVS]: ValueSet-mcode-tumor-size-units-vs.html
 
 <!-- mCODE Code Systems -->
-[ElixhauserCategoryCS]: CodeSystem-mcode-comorbidities-elixhauser-ahrq-cs.html
-[RadiotherapyCS]: CodeSystem-mcode-radiotherapy-cs.html
+[ElixhauserCategoryCS]: CodeSystem-comorbidities-elixhauser.html
+[RadiotherapyCS]: CodeSystem-radiotherapy.html
 [CatchCodeCS]: CodeSystem-mcode-catch-code-cs.html
 [ResourceIdentifierCS]: CodeSystem-mcode-resource-identifier-cs.html
 

--- a/input/includes/markdown-link-references.md
+++ b/input/includes/markdown-link-references.md
@@ -123,7 +123,7 @@
 [TumorSizeUnitsVS]: ValueSet-mcode-tumor-size-units-vs.html
 
 <!-- mCODE Code Systems -->
-[ElixhauserCategoryCS]: CodeSystem-comorbidities-elixhauser.html
+[ComorbiditiesElixhauserCS]: CodeSystem-comorbidities-elixhauser.html
 [RadiotherapyCS]: CodeSystem-radiotherapy.html
 [CatchCodeCS]: CodeSystem-mcode-catch-code-cs.html
 [ResourceIdentifierCS]: CodeSystem-mcode-resource-identifier-cs.html

--- a/input/pagecontent/StructureDefinition-mcode-brachytherapy-prescription-delivery-intro.md
+++ b/input/pagecontent/StructureDefinition-mcode-brachytherapy-prescription-delivery-intro.md
@@ -21,6 +21,6 @@ The following table shows valid combinations of modality and technique for brach
 
 ### Conformance
 
-Procedure resources associated with an mCODE patient whose code is BRACHY (code system http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs) MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.
+Procedure resources associated with an mCODE patient whose code is BRACHY (code system http://terminology.hl7.org/CodeSystem/radiotherapy) MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.
 
 {% include markdown-link-references.md %}

--- a/input/pagecontent/StructureDefinition-mcode-teleradiotherapy-prescription-delivery-intro.md
+++ b/input/pagecontent/StructureDefinition-mcode-teleradiotherapy-prescription-delivery-intro.md
@@ -24,4 +24,4 @@ The following table shows valid combinations of modality and technique for exter
 
 ### Conformance
 
-Procedure resources associated with an mCODE patient whose code is EBRT (code system http://hl7.org/fhir/us/mcode/CodeSystem/mcode-radiotherapy-cs) MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.
+Procedure resources associated with an mCODE patient whose code is EBRT (code system http://terminology.hl7.org/CodeSystem/radiotherapy) MUST conform to this profile. Beyond this requirement, a producer of resources SHOULD ensure that any resource instance associated with an mCODE patient that would reasonably be expected to conform to this profile SHOULD be published in this form. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.

--- a/input/pagecontent/ValueSet-mcode-brachytherapy-modality-vs-intro.md
+++ b/input/pagecontent/ValueSet-mcode-brachytherapy-modality-vs-intro.md
@@ -1,7 +1,7 @@
 
 ### Mapping from Other Vocabularies
 
-The modalities in this value set are drawn from the [radiotherapy code system](CodeSystem-mcode-radiotherapy-cs.html) defined in this Implementation Guide. Existing terminology systems do not have all the necessary codes.
+The modalities in this value set are drawn from the [radiotherapy code system][RadiotherapyCS] defined in this Implementation Guide. Existing terminology systems do not have all the necessary codes.
 
 The following table shows mappings from SNOMED CT and NCI Thesaurus to of brachytherapy modality codes. More specific (child) terms in the respective hierarchies also can be mapped to the code in the leftmost column. **This table may not be exhaustive and additional valid mappings may exist.**
 

--- a/input/pagecontent/ValueSet-mcode-brachytherapy-technique-vs-intro.md
+++ b/input/pagecontent/ValueSet-mcode-brachytherapy-technique-vs-intro.md
@@ -7,7 +7,7 @@ The following rules apply to this value set:
 
 ### Mapping from Other Vocabularies
 
-The modalities in this value set are drawn from the [radiotherapy code system](CodeSystem-mcode-radiotherapy-cs.html) defined in this Implementation Guide. Existing terminology systems do not have all the necessary codes.
+The modalities in this value set are drawn from the [radiotherapy code system][RadiotherapyCS] defined in this Implementation Guide. Existing terminology systems do not have all the necessary codes.
 
 The following table shows mappings from SNOMED CT and NCI Thesaurus to of brachytherapy modality codes. More specific (child) terms in the respective hierarchies also can be mapped to the code in the leftmost column. **This table may not be exhaustive and additional valid mappings may exist.**
 

--- a/input/pagecontent/ValueSet-mcode-teleradiotherapy-technique-vs-intro.md
+++ b/input/pagecontent/ValueSet-mcode-teleradiotherapy-technique-vs-intro.md
@@ -7,7 +7,7 @@ The following rules apply to this value set:
 
 ### Mapping from Other Vocabularies
 
-The modalities in this value set are drawn from the [radiotherapy code system](CodeSystem-mcode-radiotherapy-cs.html) defined in this Implementation Guide. Existing terminology systems do not have all the necessary codes.
+The modalities in this value set are drawn from the [radiotherapy code system](CodeSystem-radiotherapy.html) defined in this Implementation Guide. Existing terminology systems do not have all the necessary codes.
 
 The following table shows mappings from SNOMED CT and NCI Thesaurus to of brachytherapy modality codes. More specific (child) terms in the respective hierarchies also can be mapped to the code in the first column. **This table may not be exhaustive and additional valid mappings may exist.**
 

--- a/input/pagecontent/Valueset-mcode-teleradiotherapy-modality-vs-intro.md
+++ b/input/pagecontent/Valueset-mcode-teleradiotherapy-modality-vs-intro.md
@@ -1,6 +1,6 @@
 ### Mapping from Other Vocabularies
 
-The modalities in this value set are drawn from the [radiotherapy code system](CodeSystem-mcode-radiotherapy-cs.html) defined in this Implementation Guide. Existing terminology systems do not have all the necessary codes.
+The modalities in this value set are drawn from the [radiotherapy code system][RadiotherapyCS] defined in this Implementation Guide. Existing terminology systems do not have all the necessary codes.
 
 The following table shows mappings from SNOMED CT and NCI Thesaurus to teleradiotherapy modality codes. More specific (child) terms in the respective hierarchies also can be mapped to the code in the leftmost column. **This table may not be exhaustive and additional valid mappings may exist.**
 

--- a/input/pagecontent/group-assessment.md
+++ b/input/pagecontent/group-assessment.md
@@ -82,6 +82,6 @@ Vital signs are measurements of the most essential, or "vital" body functions. F
 
 ### Code Systems
 
-* [ElixhauserCategoryCS]
+* [ComorbiditiesElixhauserCS]
 
 {% include markdown-link-references.md %}

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -63,7 +63,7 @@ Finally, the "catch code" code system was established as a way to know, positive
 
 ### Code Systems Defined
 
-* [ElixhauserCategoryCS]
+* [ComorbiditiesElixhauserCS]
 * [RadiotherapyCS]
 * [CatchCodeCS]
 * [ResourceIdentifierCS]


### PR DESCRIPTION
Per Carmela, change the canonical to terminology.hl7.org on the two reusable code systems.
(I based this branch on radiotherapy-update PR to avoid merge conflicts)