### PR TITLE
Slice on profile

### DIFF
--- a/FHIR-us-mcode.xml
+++ b/FHIR-us-mcode.xml
@@ -4,7 +4,7 @@
 <version code="2.1.0" url="http://build.fhir.org/ig/HL7/fhir-mCODE-ig"/>
 <version code="2.0.0" url="http://hl7.org/fhir/us/mcode/STU2"/>
 <version code="1.16.0" url="http://hl7.org/fhir/us/mcode/2021May"/>
-<version code="1.0.1" url="http://hl7.org/fhir/us/mcode/STU1"/>
+<version code="1.0.1" deprecated="true" url="http://hl7.org/fhir/us/mcode/STU1"/>
 <version code="1.0.0" url="http://hl7.org/fhir/us/mcode/STU1"/>
 <version code="0.9.1" deprecated="true" url="http://hl7.org/fhir/us/mcode/2019Sep"/>
 <version code="0.1" deprecated="true"/>

--- a/input-cache/jiraspec.xml
+++ b/input-cache/jiraspec.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/mcode/2021May" ciUrl="http://build.fhir.org/ig/HL7/fhir-mCODE-ig" defaultVersion="2.0.0" defaultWorkgroup="cic" gitUrl="https://github.com/HL7/fhir-mCODE-ig" url="http://hl7.org/fhir/us/mcode">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/mcode/2021May" ciUrl="http://build.fhir.org/ig/HL7/fhir-mCODE-ig" defaultVersion="2.1.0" defaultWorkgroup="cic" gitUrl="https://github.com/HL7/fhir-mCODE-ig" url="http://hl7.org/fhir/us/mcode">
 <version code="current" url="http://build.fhir.org/ig/HL7/fhir-mCODE-ig"/>
+<version code="2.1.0" url="http://hl7.org/fhir/us/mcode/STU2.1"/>
 <version code="2.0.0" url="http://hl7.org/fhir/us/mcode/STU2"/>
 <version code="1.16.0" url="http://hl7.org/fhir/us/mcode/2021May"/>
-<version code="1.0.1" url="http://hl7.org/fhir/us/mcode/STU1"/>
 <version code="1.0.0" url="http://hl7.org/fhir/us/mcode/STU1"/>
 <version code="0.9.1" deprecated="true" url="http://hl7.org/fhir/us/mcode/2019Sep"/>
+<version code="1.0.1" deprecated="true" url="http://hl7.org/fhir/us/mcode/STU101"/>
 <version code="0.1" deprecated="true"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>

--- a/input-cache/txcache/usmcodeCodeSystemsnomed-requested-cs.cache
+++ b/input-cache/txcache/usmcodeCodeSystemsnomed-requested-cs.cache
@@ -22,8 +22,8 @@ e: {
   "language" : "en",
   "status" : "active",
   "expansion" : {
-    "identifier" : "urn:uuid:7df62e0a-37ed-4846-9d11-8e05d3d39a23",
-    "timestamp" : "2022-11-29T21:18:48.165Z",
+    "identifier" : "urn:uuid:1d7bf118-2188-4956-8742-9eaf2004cc28",
+    "timestamp" : "2022-12-16T14:58:38.450Z",
     "parameter" : [{
       "name" : "limitedExpansion",
       "valueBoolean" : true

--- a/input-cache/workgroups.xml
+++ b/input-cache/workgroups.xml
@@ -31,7 +31,7 @@
   <workgroup key="fm" webcode="fm" name="Financial Mgmt"/>
   <workgroup key="hcd" webcode="hcd" name="Health Care Devices"/>
   <workgroup key="hsi" name="Health Standards Integration" deprecated="true"/>
-  <workgroup key="hss" webcode="hss" name="Human and Social Services"/>
+  <workgroup key="hss" webcode="hsswg" name="Human and Social Services"/>
   <workgroup key="hta" webcode="termauth" name="HL7 Terminology Authority"/>
   <workgroup key="ic" webcode="ic" name="International Council"/>
   <workgroup key="project" name="IG Project" deprecated="true"/>

--- a/input/fsh/DEF_RuleSets.fsh
+++ b/input/fsh/DEF_RuleSets.fsh
@@ -12,17 +12,18 @@ RuleSet: CategorySlicingRules
 * category ^slicing.description = "Slicing requires the given value but allows additional categories"
 * category contains requiredCategory 1..1
 
-RuleSet: ObservationHasMemberSlicingRules
-* hasMember ^slicing.discriminator.type = #pattern  // #profile
-* hasMember ^slicing.discriminator.path = "$this.resolve().code"
-* hasMember ^slicing.rules = #open
-* hasMember ^slicing.description = "Slicing based on referenced resource code attribute."
+RuleSet: SliceReferenceOnProfile(path)
+* {path} ^slicing.discriminator.type = #profile
+* {path} ^slicing.discriminator.path = "$this.resolve()"
+* {path} ^slicing.rules = #open
+* {path} ^slicing.description = "Slicing based on profile conformance of the referenced resource."
 
-RuleSet: DiagnosticReportResultSlicingRules
-* result ^slicing.discriminator.type = #pattern
-* result ^slicing.discriminator.path = "$this.resolve().code"
-* result ^slicing.rules = #open
-* result ^slicing.description = "Slice based on the reference profile and code pattern"
+RuleSet: BundleSlice(name, min, max, short, def, class)
+* entry contains {name} {min}..{max} MS
+* entry[{name}] ^short = "{short}"
+* entry[{name}] ^definition = "{def}"
+* entry[{name}].resource only {class}
+//* entry[{name}].resource.meta.profile = Canonical({class})
 
 /* MustSupportOnReference applies an MS flag to a selected reference. For example in Reference(Patient or Practitioner), an MS can be put on Practitioner without a MS on Patient. In some cases, this might better than using an "only" rule
 For example, given that Practitioner is element [1] in the element "recorder":
@@ -41,13 +42,6 @@ RuleSet: CreateComponent(sliceName, min, max)
 * component[{sliceName}].code MS
 * component[{sliceName}].value[x] MS
 //* component[{sliceName}].dataAbsentReason MS
-
-RuleSet: BundleSlice(name, min, max, short, def, class)
-* entry contains {name} {min}..{max} MS
-* entry[{name}] ^short = "{short}"
-* entry[{name}] ^definition = "{def}"
-* entry[{name}].resource only {class}
-//* entry[{name}].resource.meta.profile = Canonical({class})
 
 RuleSet: SNOMEDCopyrightForVS
 * ^copyright = "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement"

--- a/input/fsh/SD_Staging.fsh
+++ b/input/fsh/SD_Staging.fsh
@@ -40,7 +40,7 @@ Description: "The extent of cancer reprsented by the stage group, based on a TNM
 * method 1..1  // NEW requirement 
 * method from TNMStagingMethodVS (extensible)
 * focus 1..1  // NEW requirement -- see https://jira.hl7.org/browse/FHIR-37575
-* insert ObservationHasMemberSlicingRules
+* insert SliceReferenceOnProfile(hasMember)
 * hasMember contains
     tnmPrimaryTumorCategory 0..1 MS and
     tnmRegionalNodesCategory 0..1 MS and


### PR DESCRIPTION
From: Karl B. Naden <knaden@mitre.org> 
Sent: Friday, December 16, 2022 10:04 AM
To: Dr. Mark A Kramer <MKRAMER@mitre.org>
Cc: Saul A Kravitz <skravitz@mitre.org>
Subject: Re: mCODE slicing definition potential issue

That’s what I would recommend doing, and Saul agrees.

From: Dr. Mark A Kramer <[MKRAMER@mitre.org](mailto:MKRAMER@mitre.org)>
Date: Friday, December 16, 2022 at 9:36 AM
To: Karl B. Naden <[knaden@mitre.org](mailto:knaden@mitre.org)>
Subject: RE: mCODE slicing definition potential issue
OK, I see your point.
I think I can change the slicing on profile if you think it would work better.
Do you want me to do that?
 
From: Karl B. Naden <[knaden@mitre.org](mailto:knaden@mitre.org)> 
Sent: Friday, December 16, 2022 12:09 AM
To: Dr. Mark A Kramer <[MKRAMER@mitre.org](mailto:MKRAMER@mitre.org)>
Subject: Re: mCODE slicing definition potential issue
 
Complexity is in generating the FHIRPath.
 
Here’s an example of a typical element definitions that is defining a slice based on presence in a value set. This is from UScore and the element defining the us-core slice has an explicit binding to a value set (highlighted in yellow), which I can use to generate a FHIRPath to filter category values down to ones that are members of this slice:
 
MedicationRequest.category.where($this.memberOf('http://hl7.org/fhir/ValueSet/medicationrequest-category'))
 
{
        "id": "MedicationRequest.category",
        "path": "MedicationRequest.category",
        "slicing": {
          "discriminator": [
            {
              "type": "pattern",
              "path": "$this"
            }
          ],
          "rules": "open"
        },
        "min": 0,
        "max": "*",
        "type": [ { "code": "CodeableConcept" } ],
        "mustSupport": true
        
}
 
{
        "id": "MedicationRequest.category:us-core",
        "path": "MedicationRequest.category",
        "sliceName": "us-core",
        "min": 0,
        "max": "*",
        "type": [ { "code": "CodeableConcept" } ],
        "mustSupport": true,
        "binding": {
          "strength": "required",
          "description": "The type of medication order.",
          "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-category"
         }
}
 
In contrast, your definition leaves that value set implicit based on association with a specific profile. That’s the complexity I’m concerned about because the information needed to generate a FHIRPath like the one above is no longer present in the element definition itself (though you could imagine the IG publisher filling it in).  In contrast, a profile-based FHIRPath could be generated with the information available (again see highlighted info)
 
hasMember.where($this.resolve().conformsTo(‘http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-primary-tumor-category’)
 
{
        "id": "Observation.hasMember",
        "path": "Observation.hasMember",
        "slicing": {
          "discriminator": [
            {
              "type": "pattern",
              "path": "$this.resolve().code"
            }
          ],
          "description": "Slicing based on referenced resource code attribute.",
          "rules": "open"
        },
        "min": 0,
        "max": "*",
        "type": [
          {
            "code": "Reference",
            "targetProfile": [
              "http://hl7.org/fhir/StructureDefinition/Observation",
              "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
              "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
            ]
          }
        ],
        "mustSupport": true
},
{
        "id": "Observation.hasMember:tnmPrimaryTumorCategory",
        "path": "Observation.hasMember",
        "sliceName": "tnmPrimaryTumorCategory",
        "min": 0,
        "max": "1",
        "type": [
          {
            "code": "Reference",
            "targetProfile": [
              "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-primary-tumor-category"
            ]
          }
        ],
        "mustSupport": true
      }
 
Neither functions conformsTo nor memberOf seem to be well supported in FHIRPath engines, so not clear which is better, but again the point is that by putting critical information to understand the slicing somewhere else, you increase the complexity.
 
Karl
 
 
From: Dr. Mark A Kramer <[MKRAMER@mitre.org](mailto:MKRAMER@mitre.org)>
Date: Thursday, December 15, 2022 at 4:51 PM
To: Karl B. Naden <[knaden@mitre.org](mailto:knaden@mitre.org)>
Subject: RE: mCODE slicing definition potential issue
I think so, but I’m not sure what “layer of complexity” you are referring to. In the FHIR Path?
 
From: Karl B. Naden <[knaden@mitre.org](mailto:knaden@mitre.org)> 
Sent: Thursday, December 15, 2022 4:46 PM
To: Dr. Mark A Kramer <[MKRAMER@mitre.org](mailto:MKRAMER@mitre.org)>; Saul A Kravitz <[skravitz@mitre.org](mailto:skravitz@mitre.org)>
Subject: Re: mCODE slicing definition potential issue
 
For my purposes, I’m trying to generate a FHIRPath where clause that will select only members of the slice. With a profile-based slicing, I at least theoretically have all the information I need to do so in the element definition itself:
 
hasMember.where($this.resolve().conformsTo([targetProfile])
 
In your formulation, I need somehow to get the information on the codes, or have it embedded in the element definitions somehow. Now that I’ve confirmed what you were thinking about in this formulation, I should be able to go over to the other structure definition and find that information and I think I agree that
1.	Slicing based on the code is nicer since checking code membership is going to be a cheaper operation (a subset actually) of profile validation.
2.	Avoiding duplication of the code details into the refering profile is beneficial.
On the other hand, it adds another layer of complexity on top of slicing, which is already quite complex.
 
Am I making sense?
 
Karl
 
From: Dr. Mark A Kramer <[MKRAMER@mitre.org](mailto:MKRAMER@mitre.org)>
Date: Thursday, December 15, 2022 at 4:33 PM
To: Saul A Kravitz <[skravitz@mitre.org](mailto:skravitz@mitre.org)>, Karl B. Naden <[knaden@mitre.org](mailto:knaden@mitre.org)>
Subject: RE: mCODE slicing definition potential issue
I think so, if you were slicing on profile. But for Observations, the code identifies the type of Observation. So that’s why we sliced on code.
 
From: Saul A Kravitz <[skravitz@mitre.org](mailto:skravitz@mitre.org)> 
Sent: Thursday, December 15, 2022 4:17 PM
To: Karl B. Naden <[knaden@mitre.org](mailto:knaden@mitre.org)>; Dr. Mark A Kramer <[MKRAMER@mitre.org](mailto:MKRAMER@mitre.org)>
Subject: Re: mCODE slicing definition potential issue
 
Just piling on.   The generic, slicing by profile should look like this, right?

RuleSet: OpenProfileBasedSlicing(field)
* {field} ^slicing.discriminator.type = #profile
* {field} ^slicing.discriminator.path = “$this.resolve()”
* {field} ^slicing.rules = #open
* {field} ^slicing.description = “Slicing based on the profile”


Nice catch by Karl, IMHO.
________________________________________
From: Karl B. Naden <[knaden@mitre.org](mailto:knaden@mitre.org)>
Sent: Thursday, December 15, 2022 4:11 PM
To: Dr. Mark A Kramer <[MKRAMER@mitre.org](mailto:MKRAMER@mitre.org)>
Cc: Saul A Kravitz <[skravitz@mitre.org](mailto:skravitz@mitre.org)>
Subject: mCODE slicing definition potential issue 
 
Hi Mark,
 
While working on generating must support TestScripts for mCODE, I found what looks to me to be a mistake in the slicing definition of some of the mCODE profiles, specifically, the [tnm stage group profile](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/StructureDefinition-mcode-tnm-stage-group.html). The [hasMember element](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/StructureDefinition-mcode-tnm-stage-group-definitions.html#diff_Observation.hasMember) is sliced on “pattern @ $this.resolve().code”, when it seems like it should be “profile @ $this.resolve()” like the [result element](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/StructureDefinition-mcode-genomics-report-definitions.html#DiagnosticReport.result) of the [Genomics Report profile](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/StructureDefinition-mcode-genomics-report.html). I this by Saul and he saw some FSH rulesets that seemed a bit suspicious to him, including the ObservationHasMemberSlicingRules definition.
 
Can you comment on whether this is intentional or not? If it is, where would I find the code pattern or value set to use for identifying members of the slice?
 
Thanks,
 
Karl