### PR TITLE
FHIR-39360: Update SD_Condition.fsh

### DIFF
--- a/input/fsh/SD_Condition.fsh
+++ b/input/fsh/SD_Condition.fsh
@@ -27,6 +27,8 @@ Description: "Records the the primary cancer condition, the original or first ne
 * stage.type ^short = "Staging system or method used."
 * stage.type ^definition = "The type of staging used to arrive at the stage.summary value."
 * stage.type from CancerStagingMethodVS (required)
+* evidence.code from CancerDiseaseStatusEvidenceTypeVS (required)
+* evidence.code ^orderMeaning = "If more than one code or Reference is present, it is interpreted as the the physician's declaration of how the cancer was diagnosed, with the most invasive method first (e.g., autopsy/histopathology, cytology, radiology, physicial exam, etc.)"
 
 
 Profile: SecondaryCancerCondition
@@ -47,3 +49,5 @@ Description: "Records the history of secondary neoplasms, including location(s) 
 * code from SecondaryCancerDisorderVS (extensible)
 * insert NotUsed(stage)
 * extension and extension[relatedPrimaryCancerCondition] MS
+* evidence.code from CancerDiseaseStatusEvidenceTypeVS (required)
+* evidence.code ^orderMeaning = "If more than one code or Reference is present, it is interpreted as the the physician's declaration of how the cancer was diagnosed, with the most invasive method first (e.g., autopsy/histopathology, cytology, radiology, physicial exam, etc.)"


### PR DESCRIPTION
Response to FHIR-39360: Condition.evidence.code is the appropriate place to put the evidence for a condition (for any condition, including primary and secondary cancers). It is a repeated (0..*) element, so multiple evidence types can be cited. What seems to be missing is a declaration that order should be interpreted as priority (this is ElementDefinition.orderMeaning) and a value set binding to the same value set as used in CancerDiseaseStatus (i.e., Cancer Disease Status Evidence Type Value Set). An extension is not required.