### PR TITLE
Replace is-a with descendent-of

### DIFF
--- a/input-cache/txcache/usmcodeCodeSystemsnomed-requested-cs.cache
+++ b/input-cache/txcache/usmcodeCodeSystemsnomed-requested-cs.cache
@@ -6,58 +6,6 @@
     "include" : [{
       "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs",
       "concept" : [{
-        "code" : "USCRS-34356",
-        "display" : "Bowel space (body structure)"
-      },
-      {
-        "code" : "USCRS-34358",
-        "display" : "Small bowel space (body structure)"
-      }]
-    }]
-  }
-}}####
-e: {
-  "valueSet" : {
-  "resourceType" : "ValueSet",
-  "language" : "en",
-  "status" : "active",
-  "expansion" : {
-    "identifier" : "urn:uuid:66d11e7d-6de7-4ac4-b121-908c810201f9",
-    "timestamp" : "2023-03-16T14:58:08.015Z",
-    "parameter" : [{
-      "name" : "limitedExpansion",
-      "valueBoolean" : true
-    },
-    {
-      "name" : "excludeNested",
-      "valueBoolean" : true
-    },
-    {
-      "name" : "version",
-      "valueUri" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs|2023May"
-    }],
-    "contains" : [{
-      "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs",
-      "code" : "USCRS-34356",
-      "display" : "Bowel space (body structure)"
-    },
-    {
-      "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs",
-      "code" : "USCRS-34358",
-      "display" : "Small bowel space (body structure)"
-    }]
-  }
-},
-  "error" : ""
-}
--------------------------------------------------------------------------------------
-{"hierarchical" : false, "valueSet" :{
-  "resourceType" : "ValueSet",
-  "compose" : {
-    "inactive" : true,
-    "include" : [{
-      "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs",
-      "concept" : [{
         "code" : "USCRS-34777",
         "display" : "Lymph node level IIA (qualifier value)"
       },
@@ -74,8 +22,8 @@ e: {
   "language" : "en",
   "status" : "active",
   "expansion" : {
-    "identifier" : "urn:uuid:ee2a2b3d-78cb-47ac-a8c1-2a9d3aa7198c",
-    "timestamp" : "2023-03-16T14:58:10.968Z",
+    "identifier" : "urn:uuid:3ab43867-4681-4e31-ae44-57313d31420c",
+    "timestamp" : "2023-03-20T15:46:54.293Z",
     "parameter" : [{
       "name" : "limitedExpansion",
       "valueBoolean" : true
@@ -86,7 +34,7 @@ e: {
     },
     {
       "name" : "version",
-      "valueUri" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs|2023May"
+      "valueUri" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs|3.0.0-ballot"
     }],
     "contains" : [{
       "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs",
@@ -97,6 +45,58 @@ e: {
       "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs",
       "code" : "USCRS-34775",
       "display" : "Lymph node level IIB (qualifier value)"
+    }]
+  }
+},
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : false, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "inactive" : true,
+    "include" : [{
+      "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs",
+      "concept" : [{
+        "code" : "USCRS-34356",
+        "display" : "Bowel space (body structure)"
+      },
+      {
+        "code" : "USCRS-34358",
+        "display" : "Small bowel space (body structure)"
+      }]
+    }]
+  }
+}}####
+e: {
+  "valueSet" : {
+  "resourceType" : "ValueSet",
+  "language" : "en",
+  "status" : "active",
+  "expansion" : {
+    "identifier" : "urn:uuid:0a2a3536-b438-4cb5-967d-c8e1257babb8",
+    "timestamp" : "2023-03-20T15:46:56.199Z",
+    "parameter" : [{
+      "name" : "limitedExpansion",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "excludeNested",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "version",
+      "valueUri" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs|3.0.0-ballot"
+    }],
+    "contains" : [{
+      "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs",
+      "code" : "USCRS-34356",
+      "display" : "Bowel space (body structure)"
+    },
+    {
+      "system" : "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs",
+      "code" : "USCRS-34358",
+      "display" : "Small bowel space (body structure)"
     }]
   }
 },

--- a/input/fsh/VS_Other.fsh
+++ b/input/fsh/VS_Other.fsh
@@ -47,7 +47,7 @@ Description: "Includes surgical procedure codes from SNOMED CT, ICD-10-PCS and C
 * ^copyright = "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement. Current Procedural Terminology (CPT) is copyright 2020 American Medical Association. All rights reserved"
 * ^experimental = false
 * ^extension[FMM].valueInteger = 3
-* include codes from system SCT where concept is-a #387713003 "Surgical procedure (procedure)"
+* include codes from system SCT where concept descendant-of #387713003 "Surgical procedure (procedure)"
 * include codes from system CPT
 * include codes from system ICD10PCS
 
@@ -57,8 +57,8 @@ Title: "Body Location and Laterality Qualifier Value Set"
 Description: "Qualifiers to refine a body structure or location including qualifiers for relative location, directionality, number, plane, and laterality."
 * insert SNOMEDCopyrightForVS
 * ^extension[FMM].valueInteger = 4
-* include codes from system SCT where concept is-a #106233006 "Topographic Modifier (qualifer)"
-* include codes from system SCT where concept is-a #272424004 "Relative Sites (qualifier)"
+* include codes from system SCT where concept descendant-of #106233006 "Topographic Modifier (qualifer)"
+* include codes from system SCT where concept descendant-of #272424004 "Relative Sites (qualifier)"
 * SCT#255503000 "Entire (qualifier value)"
 
 ValueSet: LateralityQualifierVS
@@ -98,6 +98,7 @@ Description:  "Values used to describe the reasons for stopping a treatment or e
 * SCT#309846006   "Treatment not available (situation)"
 * SCT#399307001   "Lost to follow-up (finding)" // added by mCODE Exec Council recommendation 2/12/2021
 * SCT#419620001   "Death (event)"  // FHIR-32832  (but why not 419099009 Dead (finding) because other values are findings or situations?)
+* SCT#7058009     "Noncompliance with treatment (finding)" //currently not in TerminationReason
 
 ValueSet:		ProcedureIntentVS
 Id: mcode-procedure-intent-vs

--- a/input/fsh/VS_Radiotherapy.fsh
+++ b/input/fsh/VS_Radiotherapy.fsh
@@ -221,7 +221,7 @@ Title: "Radiotherapy Treatment Location Qualifier Value Set"
 Description: "Various modifiers that can be applied to body locations where radiotherapy treatments can be directed."
 * insert SNOMEDCopyrightForVS
 * ^extension[FMM].valueInteger = 3
-* include codes from system SCT where concept is-a #258399006  "Lymph node level value (qualifier value)"  // I, II, III, IV, V, VI, VII and sub-levels
+* include codes from system SCT where concept descendant-of #258399006  "Lymph node level value (qualifier value)"  // I, II, III, IV, V, VI, VII and sub-levels
 * exclude SCT#258399006 // the top level abstract code is excluded
 * include codes from valueset LateralityQualifierVS
 // * SCT#255549009    "Anterior (qualifier value)" -- NOT USED BY TG263

--- a/input/fsh/VS_Staging.fsh
+++ b/input/fsh/VS_Staging.fsh
@@ -6,23 +6,23 @@ Title: "Cancer Staging Method Value Set"
 Description: "System or method used for staging cancers. The terms in this value set describe staging systems, not specific stages or descriptors used within those systems."
 * insert SNOMEDCopyrightForVS
 * ^extension[FMM].valueInteger = 4
-* include codes from system SCT where concept is-a #254292007 "Tumor staging (tumor staging)"
+* include codes from system SCT where concept descendant-of #254292007 "Tumor staging (tumor staging)"
 * SCT#1149162008 "International Staging System for multiple myeloma (staging scale)"
 * SCT#1149163003 "Revised International Staging System for multiple myeloma (staging scale)"
 * SCT#246165003 "Extent of disease (attribute)"  // instead of NCI#C174125 "Neoplastic Disease Extent Indicator"
 * SCT#418414003 "The revised European-American Lymphoma classification (qualifier value)"
 * SCT#418823005 "The World Health Organization classification of lymphoid malignancies (qualifier value)"
-* exclude codes from system SCT where concept is-a #258318002 "Generic anatomical site tumor invasion status (tumor staging)"
-* exclude codes from system SCT where concept is-a #258309004 "Generic lymph node tumor invasion status stage (tumor staging)"
-* exclude codes from system SCT where concept is-a #258233007 "Generic tumor staging descriptor (tumor staging)"
-* exclude codes from system SCT where concept is-a #258271004 "Specific tumor staging descriptor (tumor staging)"
+* exclude codes from system SCT where concept descendant-of #258318002 "Generic anatomical site tumor invasion status (tumor staging)"
+* exclude codes from system SCT where concept descendant-of #258309004 "Generic lymph node tumor invasion status stage (tumor staging)"
+* exclude codes from system SCT where concept descendant-of #258233007 "Generic tumor staging descriptor (tumor staging)"
+* exclude codes from system SCT where concept descendant-of #258271004 "Specific tumor staging descriptor (tumor staging)"
 * exclude SCT#42114005 "Walter Reed stage 1 (tumor staging)"
 * exclude SCT#15972002 "Walter Reed stage 2 (tumor staging)"
 * exclude SCT#13808002 "Walter Reed stage 3 (tumor staging)"
 * exclude SCT#74542008 "Walter Reed stage 4 (tumor staging)"
 * exclude SCT#66470009 "Walter Reed stage 5 (tumor staging)"
 * exclude SCT#83200007 "Walter Reed stage 6 (tumor staging)"
-
+#1
 
 ValueSet: CancerStagingTypeVS
 Id: mcode-cancer-staging-type-vs
@@ -31,27 +31,37 @@ Description: "Identifying codes for the type of cancer staging performed. In ter
 //* insert LOINCCopyrightForVS
 * insert SNOMEDCopyrightForVS
 * ^extension[FMM].valueInteger = 4
-* include codes from system SCT where concept is-a #371508000 "Tumor stage (observable entity)"
+* include codes from system SCT where concept descendant-of #371508000 "Tumor stage (observable entity)"
 * include codes from system SCT where concept is-a #385361009 "International Federation of Gynecology and Obstetrics stage for gynecological malignancy (observable entity)"
 * include codes from system SCT where concept is-a #405931009 "National Wilms Tumor Study Group Stage (observable entity)"
 * SCT#409720004 "International neuroblastoma staging system stage (observable entity)"
 * SCT#385357003 "Dukes stage (observable entity)"
 * SCT#103420007 "Modified Dukes stage (observable entity)"
-//* include codes from valueset TNMStageGroupStagingTypeVS
-//* include codes from valueset TNMPrimaryTumorStagingTypeVS
-//* include codes from valueset TNMRegionalNodesStagingTypeVS
-//* include codes from valueset TNMDistantMetastasesStagingTypeVS
 
 ValueSet: CancerStageVS
 Id: mcode-cancer-stage-group-vs
 Title: "Cancer Stage Group Value Set"
 Description: "The result of cancer staging, i.e., the stage or category of the cancer."
 * insert SNOMEDCopyrightForVS
-* include codes from system SCT where concept is-a #1222584008 "American Joint Committee on Cancer allowable value (qualifier value)"
-* include codes from system SCT where concept is-a #258318002 "Generic anatomical site tumor invasion status (tumor staging)"
-* include codes from system SCT where concept is-a #258309004 "Generic lymph node tumor invasion status stage (tumor staging)"
-* include codes from system SCT where concept is-a #258233007 "Generic tumor staging descriptor (tumor staging)"
-* include codes from system SCT where concept is-a #258271004 "Specific tumor staging descriptor (tumor staging)"
+* include codes from system SCT where concept descendant-of #1222585009 "American Joint Committee on Cancer clinical T category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222587001 "American Joint Committee on Cancer clinical M category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222588006 "American Joint Committee on Cancer clinical N category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222589003 "American Joint Committee on Cancer pathological T category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222590007 "American Joint Committee on Cancer pathological N category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222591006 "American Joint Committee on Cancer pathological M category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222592004 "American Joint Committee on Cancer clinical stage group allowable value"
+* include codes from system SCT where concept descendant-of #1222593009 "American Joint Committee on Cancer pathological stage group allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222594003 "American Joint Committee on Cancer yp stage group allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222595002 "American Joint Committee on Cancer ypT category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222596001 "American Joint Committee on Cancer ypN category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222598000 "American Joint Committee on Cancer clinical grade allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222599008 "American Joint Committee on Cancer pathological grade allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222600006 "American Joint Committee on Cancer yp grade allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222601005 "American Joint Committee on Cancer residual tumor allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #258318002 "Generic anatomical site tumor invasion status (tumor staging)"
+* include codes from system SCT where concept descendant-of #258309004 "Generic lymph node tumor invasion status stage (tumor staging)"
+* include codes from system SCT where concept descendant-of #258233007 "Generic tumor staging descriptor (tumor staging)"
+* include codes from system SCT where concept descendant-of #258271004 "Specific tumor staging descriptor (tumor staging)"
 * include SCT#42114005 "Walter Reed stage 1 (tumor staging)"
 * include SCT#15972002 "Walter Reed stage 2 (tumor staging)"
 * include SCT#13808002 "Walter Reed stage 3 (tumor staging)"
@@ -88,9 +98,9 @@ Title: "TNM Stage Group Value Set"
 Description: "Result values for cancer stage group using TNM staging. This value set contains SNOMED-CT equivalents of AJCC codes for Stage Group, according to TNM staging rules."
 * insert SNOMEDCopyrightForVS
 * ^extension[FMM].valueInteger = 4
-* include codes from system SCT where concept is-a #1222592004 "American Joint Committee on Cancer clinical stage group allowable value (qualifier value)"
-* include codes from system SCT where concept is-a #1222593009 "American Joint Committee on Cancer pathological stage group allowable value (qualifier value)"
-* include codes from system SCT where concept is-a #1222594003 "American Joint Committee on Cancer yp stage group allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222592004 "American Joint Committee on Cancer clinical stage group allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222593009 "American Joint Committee on Cancer pathological stage group allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222594003 "American Joint Committee on Cancer yp stage group allowable value (qualifier value)"
 
 ValueSet: TNMStageGroupMaxVS
 Id: mcode-tnm-stage-group-max-vs
@@ -118,9 +128,9 @@ Title: "TNM Primary Tumor Category Value Set"
 Description: "Result values for T category. This value set contains SNOMED-CT equivalents of AJCC codes for the T category, according to TNM staging rules."
 * insert SNOMEDCopyrightForVS
 * ^extension[FMM].valueInteger = 4
-* include codes from system SCT where concept is-a #1222585009 "American Joint Committee on Cancer clinical T category allowable value (qualifier value)"
-* include codes from system SCT where concept is-a #1222589003 "American Joint Committee on Cancer pathological T category allowable value (qualifier value)"
-* include codes from system SCT where concept is-a #1222595002 "American Joint Committee on Cancer ypT category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222585009 "American Joint Committee on Cancer clinical T category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222589003 "American Joint Committee on Cancer pathological T category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222595002 "American Joint Committee on Cancer ypT category allowable value (qualifier value)"
 
 ValueSet: TNMPrimaryTumorCategoryMaxVS
 Id: mcode-tnm-primary-tumor-category-max-vs
@@ -148,9 +158,9 @@ Title: "TNM Regional Nodes Category Value Set"
 Description: "Result values for N category. This value set contains SNOMED-CT equivalents of AJCC codes for the N category, according to TNM staging rules."
 * insert SNOMEDCopyrightForVS
 * ^extension[FMM].valueInteger = 4
-* include codes from system SCT where concept is-a #1222588006 "American Joint Committee on Cancer clinical N category allowable value (qualifier value)"
-* include codes from system SCT where concept is-a #1222590007 "American Joint Committee on Cancer pathological N category allowable value (qualifier value)"
-* include codes from system SCT where concept is-a #1222596001 "American Joint Committee on Cancer ypN category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222588006 "American Joint Committee on Cancer clinical N category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222590007 "American Joint Committee on Cancer pathological N category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222596001 "American Joint Committee on Cancer ypN category allowable value (qualifier value)"
 
 ValueSet: TNMRegionalNodesCategoryMaxVS
 Id: mcode-tnm-regional-nodes-category-max-vs
@@ -178,8 +188,8 @@ Title: "TNM Distant Metastases Category Value Set"
 Description: "Result values for M category. This value set contains SNOMED-CT equivalents of AJCC codes for the M category, according to TNM staging rules."
 * insert SNOMEDCopyrightForVS
 * ^extension[FMM].valueInteger = 4
-* include codes from system SCT where concept is-a #1222587001 "American Joint Committee on Cancer clinical M category allowable value (qualifier value)"
-* include codes from system SCT where concept is-a #1222591006 "American Joint Committee on Cancer pathological M category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222587001 "American Joint Committee on Cancer clinical M category allowable value (qualifier value)"
+* include codes from system SCT where concept descendant-of #1222591006 "American Joint Committee on Cancer pathological M category allowable value (qualifier value)"
 
 ValueSet: TNMDistantMetastasesCategoryMaxVS
 Id: mcode-tnm-distant-metastases-category-max-vs

--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -61,6 +61,8 @@ Based on user feedback on the complexity of the STU 2 design, [comorbidities][Co
     * SCT#246165003 "Extent of disease (attribute)"
   * Temporary codes for lymph node levels IIA and IIB, missing from previous versions, were added.
   * A code for "multiple" was added to RadiotherapyTreatmentLocationQualifierVS
+  * "Noncompliance with treatment (finding)" was added to TreatmentTerminationReasonVS
+  * In some intensionally-defined SNOMED CT value sets, the `is-a` operator was replaced with the `descendant-of` operator, removing the top-level code when it was not a valid choice.
 
 ### Update to US Core 5.0.1
 


### PR DESCRIPTION
Some top level codes in hierarchies intensionally-defined were not valid choices. Removed by replacing the is-a operator with descendant-of