### PR TITLE
Address FHIR-41031 - loosen binding strength for StageType on PrimaryCancerCondition

### DIFF
--- a/input/fsh/SD_Condition.fsh
+++ b/input/fsh/SD_Condition.fsh
@@ -19,7 +19,7 @@ Description: "Records the the primary cancer condition, the original or first ne
 * stage.summary ^definition = "Most recent overall cancer stage, such as stage group IIA in TNM staging. More detailed staging information (such as the individual T, N, and M categories) SHOULD be captured in a separate Observation resource, referenced by stage.assessment, conforming to CancerStage profile."
 * stage.type ^short = "The type of stage Staging system or method used."
 * stage.type ^definition = "The type of stage reported in stage.summary, or the staging method used to arrive at the stage.summary value."
-* stage.type from CancerStagingMethodVS (required)
+* stage.type from CancerStagingMethodVS (extensible)
 * evidence.code from CancerDiseaseStatusEvidenceTypeVS (required)
 * evidence.code ^orderMeaning = "If more than one code or Reference is present, it is interpreted as the the physician's declaration of how the cancer was diagnosed, with the most invasive method first (e.g., autopsy/histopathology, cytology, radiology, physicial exam, etc.)"
 


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-41031
"The binding strength of stage -> type is required.  Recommend changing it to extensible.  This aligns it with the binding strength in Cancer Stage Group profile - method (http://hl7.org/fhir/us/mcode/2023May/StructureDefinition-mcode-cancer-stage-group.html) which uses the same value set (http://hl7.org/fhir/us/mcode/2023May/ValueSet-mcode-cancer-staging-method-vs.html).

Also, the cancer staging method value set does not include all relevant staging methods.  Have a required binding strength would prevent the use of other relevant staging methods, such as the Toronto Childhood Cancer Stage Guidelines (http://www.iacr.com.fr/index.php?option=com_content&view=article&id=153&Itemid=657)."